### PR TITLE
feat: expose `api.worldHeight` and `api.worldWidth` and make the example bot code more interesting

### DIFF
--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -8,10 +8,17 @@ const defaultCode = `/**
  */
 function step(api) {
   const target = api.otherPlayers[0];
-  if (target) {
+  if (target && Math.random() > 0.3) {
     api.moveTowards(target);
   } else {
-    api.moveTo({ x: 0, y: 0 })
+    api.moveTo({
+      x: Math.random() > 0.5
+        ? Math.max(api.me.x - 10, 0)
+        : Math.min(api.me.x + 10, api.worldWidth),
+      y: Math.random() > 0.5
+        ? Math.max(api.me.y - 10, 0)
+        : Math.min(api.me.y + 10, api.worldHeight),
+    });
   }
 }
 
@@ -36,6 +43,8 @@ function step(api) {
  * @property {Food[]} food
  * @property {MoveTowards} moveTowards
  * @property {MoveTo} moveTo
+ * @property {number} worldHeight
+ * @property {number} worldWidth
  */
 
 /**

--- a/server/botApis/level01.js
+++ b/server/botApis/level01.js
@@ -11,6 +11,8 @@ function getBotApiV1() {
     food: global._food || [],
     moveTowards: moveTo,
     moveTo,
+    worldHeight: global._worldHeight,
+    worldWidth: global._worldWidth,
   };
 }
 

--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -53,6 +53,8 @@ async function runBots({ bots, world, botApi }: RunBotArgs) {
 global._player = ${JSON.stringify(me)};
 global._otherPlayers = ${JSON.stringify(otherPlayers)};
 global._food = ${JSON.stringify(food)};
+global._worldWidth = ${state.width};
+global._worldHeight = ${state.height};
 
 ${code}
 


### PR DESCRIPTION
## How does this PR impact the user?

### Now

https://github.com/move-fast-and-break-things/aibyss/assets/4187729/1b563aba-255a-4161-8ae0-cd6b4e9408db

### Before

https://github.com/move-fast-and-break-things/aibyss/assets/4187729/4d413f00-c88a-418d-b547-629ec6fb91e9

## Description

- [x] expose `worldHeight` and `worldWidth` on the `api` passed to the bot step function
- [x] make the example code more interesting (see video above) – instead of going to 0:0, the bot will default to do random moves

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes