### PR TITLE
ci: switch to `ubuntu-24.04` and enable `node_modules` cache

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -9,23 +9,25 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
+          cache: 'npm'
       - run: npm ci
       - run: npm run lint
       - run: npm run build
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
+          cache: 'npm'
       - run: npm ci
       - run: npm run test:e2e:install
       - run: npm run test


### PR DESCRIPTION
## How does this PR impact the user?

No impact.

## Description

Developers will be able to run CI and merge PRs faster thanks to the `node_modules` cache.

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
