### PR TITLE
fix(code editor): style new buttons as part of the editor

### DIFF
--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -59,26 +59,28 @@ function onCloseAPIReferenceModal() {
     class="w-full h-full font-sans flex flex-col"
     data-testid="code-editor"
   >
-    <div class="flex flex-row justify-end mb-2 gap-6">
-      <ButtonLink @click="onRestoreDefaultCodeClick">
-        restore example code
-      </ButtonLink>
-      <ButtonLink @click="onShowAPIReferenceClick">
-        API reference
-      </ButtonLink>
-    </div>
     <form
       class="flex flex-grow flex-col"
       @submit="onSubmit"
     >
-      <MonacoEditor
-        v-model="state.code"
-        lang="javascript"
-        class="flex-grow mb-4 shadow"
-        :options="{
-          smoothScrolling: true,
-        }"
-      />
+      <div class="flex flex-grow flex-col shadow mb-4">
+        <div class="flex flex-row justify-end mb-2 mt-1 mx-2 gap-6">
+          <ButtonLink @click="onRestoreDefaultCodeClick">
+            restore example code
+          </ButtonLink>
+          <ButtonLink @click="onShowAPIReferenceClick">
+            API reference
+          </ButtonLink>
+        </div>
+        <MonacoEditor
+          v-model="state.code"
+          lang="javascript"
+          class="flex-grow"
+          :options="{
+            smoothScrolling: true,
+          }"
+        />
+      </div>
       <div class="flex justify-end">
         <button
           type="submit"


### PR DESCRIPTION
## How does this PR impact the user?

### Now

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/77cd4d5a-9aa8-4e3f-bac0-b1d6e2d5f814">

### Before

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/a3b95503-85f5-4ba2-9a9d-f48627f04b24">

## Description

- [x] этот PR делает новые кнопки "restore example code" и "API reference" частью редактора кота

## Limitations

Нет.

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
