### PR TITLE
quickfix(world): game stats should count bot deaths

### DIFF
--- a/utils/world.ts
+++ b/utils/world.ts
@@ -244,7 +244,7 @@ export default class World {
           continue;
         }
         botStats.kills += 1;
-        otherBotStats.deaths + 1;
+        otherBotStats.deaths += 1;
       }
     }
 


### PR DESCRIPTION
## How does this PR impact the user?

### Before

![image](https://github.com/user-attachments/assets/87cfdd3c-c3fa-4c00-9102-5716231a4b3e)

### After (there is another bug where we lose stats for a bot if it's not in the game at the end of the game, but it's for a different PR)

<img width="739" alt="image" src="https://github.com/user-attachments/assets/b3578e6f-de81-4230-b127-42dd865e2f21">

## Description

- [x] добавил потерянный `=` в `+=`

## Limitations

Было бы здорово защитить сбор статистики тестами.

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
