### PR TITLE
fix(engine): restart the game when the bot is 1/2 of the game field height, rather than wait for it to become the game height

### DIFF
--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -70,7 +70,7 @@ function startEngine({ botApi }: StartEngineArgs) {
     runBots({ bots, world: WORLD_REF.world, botApi });
     const worldState = WORLD_REF.world.getState();
     for (const bot of worldState.bots.values()) {
-      if (bot.radius > worldState.height / 2) {
+      if (bot.radius > worldState.height / 4) {
         endGame("Player overdominating");
         console.debug(`The World was restarted cus ${bot.botId} was oversized`);
       }


### PR DESCRIPTION
## How does this PR impact the user?

### Before

![telegram-cloud-photo-size-2-5418206625677830746-y](https://github.com/user-attachments/assets/9179b43a-e265-424b-ad53-89ff6b89c265)

### After

https://www.loom.com/share/ec44b3356cb241e5b10f2b91ce6f8307

## Description

Ditto.

## Limitations

Было бы здорово защитить эту логику тестом.

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
