### PR TITLE
docs(README): remove not needed Windows setup step from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 ## Setup
 
 - install [node.js](https://nodejs.org/en)
-- **(on Windows and macOS)** install `node-gyp`: `npm install -g node-gyp`
-- **(on Windows only)** install `@rollup/rollup-win32-x64-msvc`: `npm install @rollup/rollup-win32-x64-msvc`
+- **(on macOS only)** install `node-gyp`: `npm install -g node-gyp`
 - install the dependencies: `npm ci`
 
 ## Development server


### PR DESCRIPTION
## How does this PR impact the user?

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/5b25b3f1-3202-4c73-b953-9eeaf6d596dd">

## Description

@PlutoniumSoup и @Bee133 сегодня видели, что устанавливать доп зависимости для Windows не нужно. `npm install` всё, что нужно, ставит.

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
