### PR TITLE
fix(engine): don't exclude bots not present in the world at the end of the game from the final stats calculations

### DIFF
--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -93,7 +93,7 @@ function endGame(reason: string) {
     stats: Array.from(worldState.stats.entries()).map(([botId, stat]) => {
       return {
         userId: botCodeStore.getBots()[botId]?.userId,
-        size: worldState.bots.get(WORLD_REF.world.getSpawnId(botId))?.radius,
+        size: worldState.bots.get(WORLD_REF.world.getSpawnId(botId))?.radius || 0,
         foodEaten: stat.foodEaten,
         kills: stat.kills,
         deaths: stat.deaths,

--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -93,7 +93,7 @@ function endGame(reason: string) {
     stats: Array.from(worldState.stats.entries()).map(([botId, stat]) => {
       return {
         userId: botCodeStore.getBots()[botId]?.userId,
-        size: worldState.bots.get(WORLD_REF.world.getSpawnId(botId))?.radius || 0,
+        size: worldState.bots.get(WORLD_REF.world.getSpawnId(botId))?.radius ?? 0,
         foodEaten: stat.foodEaten,
         kills: stat.kills,
         deaths: stat.deaths,


### PR DESCRIPTION
## How does this PR impact the user?

We will capture the user bot stats in the db even if they are aren't in the game by the game end.

### Before

![telegram-cloud-photo-size-2-5418206625677830756-y](https://github.com/user-attachments/assets/59eefb58-7604-4cc9-b24b-f627ea3b4d75)

### After (ignore the artificially inflated bot size – did this for the test)

<img width="794" alt="image" src="https://github.com/user-attachments/assets/d8eb9d06-3980-4d46-be42-1af5e9244551">

## Description

Ditto.

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
