### PR TITLE
fix(world): bots shouldn't be able to leave the game screen

### DIFF
--- a/other/world.spec.ts
+++ b/other/world.spec.ts
@@ -74,3 +74,63 @@ it("shouldn't crash when bot eats two food items and one of them with the last i
   // @ts-expect-error - world.food is private
   expect(world.food.length).toBeLessThan(100);
 });
+
+it("doesn't allow the bot to go outside the world with large x and y", () => {
+  const world = new World({ width: 100, height: 100 });
+  world.addBot("1");
+
+  // @ts-expect-error - world.botSpawns is private
+  const bot = [...world.botSpawns.values()].find(bot => bot.botId === "1") as BotSprite;
+  bot.x = 100;
+  bot.y = 100;
+
+  const worldStateBeforeMove = world.getState();
+  const botsBeforeMove = [...worldStateBeforeMove.bots.values()];
+  const botFromStateBeforeMove = botsBeforeMove[0];
+  if (!botFromStateBeforeMove) {
+    throw new Error("Bot not found in the state");
+  }
+  expect(botFromStateBeforeMove.x).toBe(100);
+  expect(botFromStateBeforeMove.y).toBe(100);
+
+  world.moveBot("1", 101, 101);
+
+  const worldStateAfterMove = world.getState();
+  const botsAfterMove = [...worldStateAfterMove.bots.values()];
+  const botFromStateAfterMove = botsAfterMove[0];
+  if (!botFromStateAfterMove) {
+    throw new Error("Bot not found in the state");
+  }
+  expect(botFromStateAfterMove.x).toBe(100);
+  expect(botFromStateAfterMove.y).toBe(100);
+});
+
+it("doesn't allow the bot to go outside the world with negative x and y", () => {
+  const world = new World({ width: 100, height: 100 });
+  world.addBot("1");
+
+  // @ts-expect-error - world.botSpawns is private
+  const bot = [...world.botSpawns.values()].find(bot => bot.botId === "1") as BotSprite;
+  bot.x = 0;
+  bot.y = 0;
+
+  const worldStateBeforeMove = world.getState();
+  const botsBeforeMove = [...worldStateBeforeMove.bots.values()];
+  const botFromStateBeforeMove = botsBeforeMove[0];
+  if (!botFromStateBeforeMove) {
+    throw new Error("Bot not found in the state");
+  }
+  expect(botFromStateBeforeMove.x).toBe(0);
+  expect(botFromStateBeforeMove.y).toBe(0);
+
+  world.moveBot("1", -1, -1);
+
+  const worldStateAfterMove = world.getState();
+  const botsAfterMove = [...worldStateAfterMove.bots.values()];
+  const botFromStateAfterMove = botsAfterMove[0];
+  if (!botFromStateAfterMove) {
+    throw new Error("Bot not found in the state");
+  }
+  expect(botFromStateAfterMove.x).toBe(0);
+  expect(botFromStateAfterMove.y).toBe(0);
+});

--- a/other/world.ts
+++ b/other/world.ts
@@ -201,8 +201,8 @@ export default class World {
       y = newY;
     }
 
-    bot.x = x;
-    bot.y = y;
+    bot.x = Math.max(0, Math.min(x, this.width));
+    bot.y = Math.max(0, Math.min(y, this.height));
 
     let checkLimit = 5;
     while (this.checkCollisions(botId) && --checkLimit) {


### PR DESCRIPTION
## How does this PR impact the user?

### Before – bots can leave the game screen – watch the end of the video

https://github.com/user-attachments/assets/5a827f42-c7d9-47e2-a036-922c9922e831

### After – bots can't leave the game screen

https://github.com/user-attachments/assets/3e475018-c1f0-4c57-a23e-ce565775d9c6

## Description

- [x] update `World.moveBot` to prevent bots from leaving the screen
- [x] add tests

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
