### PR TITLE
fix: game timeout timer should reset on every game start

### DIFF
--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -66,6 +66,11 @@ function startEngine({ botApi }: StartEngineArgs) {
     bots = newBots;
   });
 
+  const timerInterval = setInterval(() => {
+    endGame("Time's up");
+    console.debug(`The World was restarted after ${MAX_ROUND_TIME_MS} ms`);
+  }, MAX_ROUND_TIME_MS);
+
   setInterval(() => {
     runBots({ bots, world: WORLD_REF.world, botApi });
     const worldState = WORLD_REF.world.getState();
@@ -73,14 +78,10 @@ function startEngine({ botApi }: StartEngineArgs) {
       if (bot.radius > worldState.height / 4) {
         endGame("Player overdominating");
         console.debug(`The World was restarted cus ${bot.botId} was oversized`);
+        timerInterval.refresh();
       }
     }
   }, 250);
-
-  setInterval(() => {
-    endGame("Time's up");
-    console.debug(`The World was restarted after ${MAX_ROUND_TIME_MS} ms`);
-  }, MAX_ROUND_TIME_MS);
 }
 
 function endGame(reason: string) {

--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -66,7 +66,7 @@ function startEngine({ botApi }: StartEngineArgs) {
     bots = newBots;
   });
 
-  const timerInterval = setInterval(() => {
+  const gameTimeoutInterval = setInterval(() => {
     endGame("Time's up");
     console.debug(`The World was restarted after ${MAX_ROUND_TIME_MS} ms`);
   }, MAX_ROUND_TIME_MS);

--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -78,7 +78,7 @@ function startEngine({ botApi }: StartEngineArgs) {
       if (bot.radius > worldState.height / 4) {
         endGame("Player overdominating");
         console.debug(`The World was restarted cus ${bot.botId} was oversized`);
-        timerInterval.refresh();
+        gameTimeoutInterval.refresh();
       }
     }
   }, 250);


### PR DESCRIPTION
## How does this PR impact the user?

This PR fixes the issue where the game may end by time earlier than in the configured 15 minutes.

## Description

- [x] restart the game timeout interval object on every game start

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
