### PR TITLE
fix: "API reference" and "?" modal sizes

### DIFF
--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -111,6 +111,7 @@ function onCloseAPIReferenceModal() {
   <ModalDialog
     :open="state.showAPIReference"
     :on-close="onCloseAPIReferenceModal"
+    extra-modal-class="w-[540px]"
   >
     <MonacoEditor
       v-model="jsdoc"

--- a/components/GlobalHeader.vue
+++ b/components/GlobalHeader.vue
@@ -68,7 +68,7 @@ const onCloseAboutModal = () => {
   <ModalDialog
     :open="aboutModalOpen"
     :on-close="onCloseAboutModal"
-    extra-modal-class="h-[400px]"
+    extra-modal-class="h-[400px] max-h-[400px]"
   >
     <div class="flex flex-grow flex-col justify-between">
       <div class="flex flex-col gap-2">


### PR DESCRIPTION
## How does this PR impact the user?

### Before

<img width="1435" alt="Screenshot 2024-11-09 at 16 43 38" src="https://github.com/user-attachments/assets/553af29f-cff0-456a-bdcf-7638120f6fe3">
<img width="1435" alt="Screenshot 2024-11-09 at 16 43 35" src="https://github.com/user-attachments/assets/77ddf6af-38ac-4f17-bae1-b476d8c8410c">

### After

<img width="1435" alt="Screenshot 2024-11-09 at 16 44 49" src="https://github.com/user-attachments/assets/b2268498-4164-4a7c-9603-d94542390c43">
<img width="1435" alt="Screenshot 2024-11-09 at 16 44 53" src="https://github.com/user-attachments/assets/7971616d-2a8b-44a2-90e2-e1777eb6964c">

## Description

- [x] fix the modal sizes

The issue was accidentally introduced in this commit: https://github.com/move-fast-and-break-things/aibyss/commit/c3c3e3fb04de589cbca07343c848c875a89bd7e9.

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
