### PR TITLE
feat(rating): add "24h score" and "1h score" columns

### DIFF
--- a/components/RatingTable.vue
+++ b/components/RatingTable.vue
@@ -97,7 +97,7 @@ const { data: rating, status } = await useFetch("/api/rating");
                 {{ userRating.username }}
               </th>
               <td class="px-6 py-4">
-                {{ userRating.score }}
+                {{ userRating.score7days }}
               </td>
               <td class="px-6 py-4 bg-gray-50 dark:bg-gray-800">
                 {{ userRating.wins }}

--- a/components/RatingTable.vue
+++ b/components/RatingTable.vue
@@ -38,6 +38,18 @@ const { data: rating, status } = await useFetch("/api/rating");
                 scope="col"
                 class="px-6 py-3 bg-gray-50 dark:bg-gray-800"
               >
+                24h score
+              </th>
+              <th
+                scope="col"
+                class="px-6 py-3"
+              >
+                1h score
+              </th>
+              <th
+                scope="col"
+                class="px-6 py-3 bg-gray-50 dark:bg-gray-800"
+              >
                 wins
               </th>
               <th
@@ -98,6 +110,12 @@ const { data: rating, status } = await useFetch("/api/rating");
               </th>
               <td class="px-6 py-4">
                 {{ userRating.score7days }}
+              </td>
+              <td class="px-6 py-4 bg-gray-50 dark:bg-gray-800">
+                {{ userRating.score24hours }}
+              </td>
+              <td class="px-6 py-4">
+                {{ userRating.score1hour }}
               </td>
               <td class="px-6 py-4 bg-gray-50 dark:bg-gray-800">
                 {{ userRating.wins }}

--- a/server/api/rating.get.ts
+++ b/server/api/rating.get.ts
@@ -3,7 +3,9 @@ import prisma from "~/other/db";
 type UserRating = {
   userId: number;
   username: string;
-  score: number;
+  score7days: number;
+  score24hours: number;
+  score1hour: number;
   gamesPlayed: number;
   wins: number;
   kills: number;
@@ -36,13 +38,17 @@ export default defineEventHandler(async () => {
   });
 
   const rawUserRatings: Record<number, RawUserRating> = {};
+  const rawUserRatings24hours: Record<number, Omit<RawUserRating, "score7days" | "score24hours" | "score1hour">> = {};
+  const rawUserRatings1hour: Record<number, Omit<RawUserRating, "score7days" | "score24hours" | "score1hour">> = {};
 
   for (const game of games) {
     for (const stat of game.game_stats) {
       const userRating = rawUserRatings[stat.user_id] || (rawUserRatings[stat.user_id] = {
         userId: stat.user_id,
         username: users.find(user => user.id === stat.user_id)?.username ?? "Mysterious Stranger",
-        score: 0,
+        score7days: 0,
+        score24hours: 0,
+        score1hour: 0,
         gamesPlayed: 0,
         wins: 0,
         kills: 0,
@@ -67,10 +73,10 @@ export default defineEventHandler(async () => {
       avgEndgameSize: userRating.endgameSizes.reduce((acc, size) => acc + size, 0) / userRating.endgameSizes.length,
     };
 
-    finalRating.score = computeScore(finalRating);
+    finalRating.score7days = computeScore(finalRating);
 
     return finalRating;
-  }).sort((a, b) => b.score - a.score);
+  }).sort((a, b) => b.score7days - a.score7days);
 
   return userRatings;
 });

--- a/server/api/rating.get.ts
+++ b/server/api/rating.get.ts
@@ -1,11 +1,6 @@
 import prisma from "~/other/db";
 
-type UserRating = {
-  userId: number;
-  username: string;
-  score7days: number;
-  score24hours: number;
-  score1hour: number;
+type UserStats = {
   gamesPlayed: number;
   wins: number;
   kills: number;
@@ -15,73 +10,125 @@ type UserRating = {
   avgEndgameSize: number;
 };
 
-type RawUserRating = Omit<UserRating, "avgEndgameSize" | "maxEndgameSize"> & {
+type UserRating = UserStats & {
+  userId: number;
+  username: string;
+  score7days: number;
+  score24hours: number;
+  score1hour: number;
+};
+
+type RawStats = Omit<UserStats, "avgEndgameSize" | "maxEndgameSize"> & {
   endgameSizes: number[];
 };
 
+function getEmptyRawStats() {
+  return {
+    gamesPlayed: 0,
+    wins: 0,
+    kills: 0,
+    deaths: 0,
+    foodEaten: 0,
+    endgameSizes: [],
+  };
+}
+
+type RawUserStats = {
+  userId: number;
+  username: string;
+  stats7days: RawStats;
+  stats24hours: RawStats;
+  stats7hours: RawStats;
+};
+
 export default defineEventHandler(async () => {
-  const oneWeekAgo = new Date();
+  const now = new Date();
+
+  const oneWeekAgo = new Date(now);
   oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
 
   // don't join users to not slow down the games query with another join
   const users = await prisma.user.findMany();
-
   const games = await prisma.game.findMany({
-    where: {
-      start_time: {
-        gte: oneWeekAgo,
-      },
-    },
-    include: {
-      game_stats: true,
-    },
+    where: { start_time: { gte: oneWeekAgo } },
+    include: { game_stats: true },
   });
 
-  const rawUserRatings: Record<number, RawUserRating> = {};
-  const rawUserRatings24hours: Record<number, Omit<RawUserRating, "score7days" | "score24hours" | "score1hour">> = {};
-  const rawUserRatings1hour: Record<number, Omit<RawUserRating, "score7days" | "score24hours" | "score1hour">> = {};
+  const date24hoursAgo = new Date();
+  date24hoursAgo.setHours(date24hoursAgo.getHours() - 24);
+
+  const date7hoursAgo = new Date();
+  date7hoursAgo.setHours(date7hoursAgo.getHours() - 7);
+
+  const rawUserStats: Record<number, RawUserStats> = {};
 
   for (const game of games) {
+    const usersBySize = [...game.game_stats].sort((a, b) => b.size - a.size);
+    // the winner is the largest user by the end of the game
+    // but they shouldn't share the win with other users, otherwise it's a draw
+    const winnerUserId = usersBySize[0]?.size !== usersBySize[1]?.size ? usersBySize[0]?.user_id : undefined;
+
     for (const stat of game.game_stats) {
-      const userRating = rawUserRatings[stat.user_id] || (rawUserRatings[stat.user_id] = {
+      const user = users.find(user => user.id === stat.user_id);
+      if (!user) {
+        throw new Error(`User with id ${stat.user_id} not found`);
+      }
+
+      const rawUserStat = rawUserStats[stat.user_id] || (rawUserStats[stat.user_id] = {
         userId: stat.user_id,
-        username: users.find(user => user.id === stat.user_id)?.username ?? "Mysterious Stranger",
-        score7days: 0,
-        score24hours: 0,
-        score1hour: 0,
-        gamesPlayed: 0,
-        wins: 0,
-        kills: 0,
-        deaths: 0,
-        foodEaten: 0,
-        endgameSizes: [],
+        username: user.username,
+        stats7days: getEmptyRawStats(),
+        stats24hours: getEmptyRawStats(),
+        stats7hours: getEmptyRawStats(),
       });
 
-      userRating.gamesPlayed += 1;
-      userRating.kills += stat.kills;
-      userRating.deaths += stat.deaths;
-      userRating.foodEaten += stat.food_eaten;
-      userRating.endgameSizes.push(stat.size);
-      userRating.wins += Number(game.game_stats.every(s => s.user_id === stat.user_id || s.size < stat.size));
+      rawUserStat.stats7days.gamesPlayed += 1;
+      rawUserStat.stats7days.kills += stat.kills;
+      rawUserStat.stats7days.deaths += stat.deaths;
+      rawUserStat.stats7days.foodEaten += stat.food_eaten;
+      rawUserStat.stats7days.endgameSizes.push(stat.size);
+      rawUserStat.stats7days.wins += stat.user_id === winnerUserId ? 1 : 0;
+
+      if (game.start_time >= date24hoursAgo) {
+        rawUserStat.stats24hours.gamesPlayed += 1;
+        rawUserStat.stats24hours.kills += stat.kills;
+        rawUserStat.stats24hours.deaths += stat.deaths;
+        rawUserStat.stats24hours.foodEaten += stat.food_eaten;
+        rawUserStat.stats24hours.endgameSizes.push(stat.size);
+        rawUserStat.stats24hours.wins += stat.user_id === winnerUserId ? 1 : 0;
+      }
+
+      if (game.start_time >= date7hoursAgo) {
+        rawUserStat.stats7hours.gamesPlayed += 1;
+        rawUserStat.stats7hours.kills += stat.kills;
+        rawUserStat.stats7hours.deaths += stat.deaths;
+        rawUserStat.stats7hours.foodEaten += stat.food_eaten;
+        rawUserStat.stats7hours.endgameSizes.push(stat.size);
+        rawUserStat.stats7hours.wins += stat.user_id === winnerUserId ? 1 : 0;
+      }
     }
   }
 
-  const userRatings: UserRating[] = Object.values(rawUserRatings).map((userRating) => {
-    const finalRating = {
-      ...userRating,
-      maxEndgameSize: Math.max(...userRating.endgameSizes),
-      avgEndgameSize: userRating.endgameSizes.reduce((acc, size) => acc + size, 0) / userRating.endgameSizes.length,
+  const userRatings: UserRating[] = Object.values(rawUserStats).map((rawUserStat) => {
+    return {
+      ...rawUserStat.stats7days,
+      userId: rawUserStat.userId,
+      username: rawUserStat.username,
+      maxEndgameSize: Math.max(...rawUserStat.stats7days.endgameSizes),
+      avgEndgameSize: (
+        rawUserStat.stats7days.endgameSizes.reduce((acc, size) => acc + size, 0)
+        / rawUserStat.stats7days.endgameSizes.length
+      ),
+      score7days: computeScore(rawUserStat.stats7days),
+      score24hours: computeScore(rawUserStat.stats24hours),
+      score1hour: computeScore(rawUserStat.stats7hours),
     };
-
-    finalRating.score7days = computeScore(finalRating);
-
-    return finalRating;
   }).sort((a, b) => b.score7days - a.score7days);
 
   return userRatings;
 });
 
-function computeScore(userRating: UserRating) {
+function computeScore(userRating: RawStats) {
   return (
     userRating.wins * 50
     + userRating.kills * 10

--- a/server/api/rating.get.ts
+++ b/server/api/rating.get.ts
@@ -72,14 +72,14 @@ export default defineEventHandler(async () => {
         stats1hour: getEmptyRawStats(),
       });
 
-      rawUserStat.stats7days = bumpRawStats({
+      rawUserStat.stats7days = updateRawStats({
         rawStats: rawUserStat.stats7days,
         stats: stat,
         winnerUserId,
       });
 
       if (game.start_time > date24hoursAgo) {
-        rawUserStat.stats24hours = bumpRawStats({
+        rawUserStat.stats24hours = updateRawStats({
           rawStats: rawUserStat.stats24hours,
           stats: stat,
           winnerUserId,
@@ -87,7 +87,7 @@ export default defineEventHandler(async () => {
       }
 
       if (game.start_time > date1hourAgo) {
-        rawUserStat.stats1hour = bumpRawStats({
+        rawUserStat.stats1hour = updateRawStats({
           rawStats: rawUserStat.stats1hour,
           stats: stat,
           winnerUserId,
@@ -134,7 +134,7 @@ function getEmptyRawStats(): RawStats {
   };
 }
 
-function bumpRawStats({ rawStats, stats, winnerUserId }: {
+function updateRawStats({ rawStats, stats, winnerUserId }: {
   rawStats: RawStats;
   stats: GameStats;
   winnerUserId: number | undefined;

--- a/server/api/rating.get.ts
+++ b/server/api/rating.get.ts
@@ -72,14 +72,14 @@ export default defineEventHandler(async () => {
         stats1hour: getEmptyRawStats(),
       });
 
-      rawUserStat.stats7days = updateRawStats({
+      rawUserStat.stats7days = getUpdatedRawStats({
         rawStats: rawUserStat.stats7days,
         stats: stat,
         winnerUserId,
       });
 
       if (game.start_time > date24hoursAgo) {
-        rawUserStat.stats24hours = updateRawStats({
+        rawUserStat.stats24hours = getUpdatedRawStats({
           rawStats: rawUserStat.stats24hours,
           stats: stat,
           winnerUserId,
@@ -87,7 +87,7 @@ export default defineEventHandler(async () => {
       }
 
       if (game.start_time > date1hourAgo) {
-        rawUserStat.stats1hour = updateRawStats({
+        rawUserStat.stats1hour = getUpdatedRawStats({
           rawStats: rawUserStat.stats1hour,
           stats: stat,
           winnerUserId,
@@ -134,7 +134,7 @@ function getEmptyRawStats(): RawStats {
   };
 }
 
-function updateRawStats({ rawStats, stats, winnerUserId }: {
+function getUpdatedRawStats({ rawStats, stats, winnerUserId }: {
   rawStats: RawStats;
   stats: GameStats;
   winnerUserId: number | undefined;

--- a/server/api/rating.get.ts
+++ b/server/api/rating.get.ts
@@ -44,10 +44,10 @@ export default defineEventHandler(async () => {
     include: { game_stats: true },
   });
 
-  const date24hoursAgo = new Date();
+  const date24hoursAgo = new Date(now);
   date24hoursAgo.setHours(date24hoursAgo.getHours() - 24);
 
-  const date1hourAgo = new Date();
+  const date1hourAgo = new Date(now);
   date1hourAgo.setHours(date1hourAgo.getHours() - 1);
 
   const rawUserStats: Record<number, RawUserStats> = {};


### PR DESCRIPTION
## How does this PR impact the user?

### Before

<img width="1424" alt="Screenshot 2024-11-10 at 09 40 59" src="https://github.com/user-attachments/assets/6133a5a0-2417-4445-9fe3-a840990b932e">

### After

<img width="1424" alt="Screenshot 2024-11-10 at 09 40 29" src="https://github.com/user-attachments/assets/d0c8764c-2ad4-4b62-9ee0-2d094cc2319d">

## Description

- [x] update `rating.get.ts` to compute stats and scores for the last 24 hours and the last 1 hour in addition to the last 7 days
- [x] update the `RatingTable` to display the scores
- [x] refactor it a bit

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
