### PR TITLE
feat(rating): add hourly score graph

### DIFF
--- a/components/RatingChart.vue
+++ b/components/RatingChart.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { Chart } from "chart.js/auto";
+import { setRgbColorOpacity } from "~/other/setRgbColorOpacity";
+import type { UserRating } from "~/server/api/rating.get";
+
+const { rating } = defineProps<{ rating: UserRating[] }>();
+
+const chart = ref<HTMLCanvasElement | null>(null);
+
+onMounted(() => {
+  if (!chart.value) {
+    throw new Error("chartContainer is not defined");
+  }
+
+  new Chart(
+    chart.value,
+    {
+      type: "line",
+      data: {
+        labels: rating[0]?.scoreDynamic1hour.map((_, index) => index),
+        datasets: rating.map(userRating => ({
+          label: userRating.username,
+          data: userRating.scoreDynamic1hour,
+          pointStyle: false,
+          tension: 0.2,
+          borderWidth: 2,
+        })),
+      },
+      options: {
+        responsive: true,
+        interaction: {
+          mode: "index",
+          intersect: false,
+        },
+        plugins: {
+          legend: {
+            position: "bottom",
+            onHover(event, legendItem, legend) {
+              for (const [idx, dataset] of legend.chart.data.datasets.entries()) {
+                if (typeof dataset.borderColor !== "string") {
+                  throw new Error("unexpected borderColor");
+                }
+                dataset.borderColor = setRgbColorOpacity({
+                  color: dataset.borderColor,
+                  opacity: idx !== legendItem.datasetIndex ? 0.2 : 1,
+                });
+              }
+              legend.chart.update();
+            },
+            onLeave(event, legendItem, legend) {
+              for (const dataset of legend.chart.data.datasets) {
+                if (typeof dataset.borderColor !== "string") {
+                  throw new Error("unexpected borderColor");
+                }
+                dataset.borderColor = setRgbColorOpacity({
+                  color: dataset.borderColor,
+                  opacity: 1,
+                });
+              }
+              legend.chart.update();
+            },
+          },
+          title: {
+            display: true,
+            text: "1 hour score graph over the previous 7 days",
+          },
+        },
+      },
+    },
+  );
+});
+</script>
+
+<template>
+  <canvas ref="chart" />
+</template>

--- a/components/RatingTable.vue
+++ b/components/RatingTable.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 const { data: rating, status } = await useFetch("/api/rating");
+
+const isModalOpen = ref(false);
 </script>
 
 <template>
-  <div class="flex flex-col mx-auto items-center max-w-full">
+  <div class="flex flex-col mx-auto items-center max-w-full gap-8">
     <div class="text-lg font-semibold">
       Player rating for the last 7 days
     </div>
 
-    <div class="flex mx-auto relative overflow-x-auto shadow-md mt-8 max-w-full">
+    <div class="flex mx-auto relative overflow-x-auto shadow-md max-w-full">
       <div v-if="status === 'pending'">
         Loading...
       </div>
@@ -44,7 +46,12 @@ const { data: rating, status } = await useFetch("/api/rating");
                 scope="col"
                 class="px-6 py-3"
               >
-                1h score
+                <ButtonLink
+                  class="uppercase text-left"
+                  @click="isModalOpen = true"
+                >
+                  1h score
+                </ButtonLink>
               </th>
               <th
                 scope="col"
@@ -146,5 +153,16 @@ const { data: rating, status } = await useFetch("/api/rating");
         </div>
       </div>
     </div>
+
+    <ModalDialog
+      :open="isModalOpen"
+      :on-close="() => (isModalOpen = false)"
+      extra-modal-class="max-w-[800px] min-h-0 h-auto w-[800px]"
+    >
+      <RatingChart
+        v-if="rating"
+        :rating="rating"
+      />
+    </ModalDialog>
   </div>
 </template>

--- a/other/setRgbColorOpacity.test.ts
+++ b/other/setRgbColorOpacity.test.ts
@@ -1,0 +1,36 @@
+import { it, describe, expect } from "vitest";
+import { setRgbColorOpacity } from "./setRgbColorOpacity";
+
+describe("setRgbColorOpacity", () => {
+  it("should set the opacity of an rgb color", () => {
+    const color = "rgb(255, 0, 0)";
+    const opacity = 0.5;
+    const result = setRgbColorOpacity({ color, opacity });
+    expect(result).toBe("rgba(255, 0, 0, 0.5)");
+  });
+
+  it("should set the opacity of an rgba color", () => {
+    const color = "rgba(255, 39, 128, 0.2)";
+    const opacity = 0.5;
+    const result = setRgbColorOpacity({ color, opacity });
+    expect(result).toBe("rgba(255, 39, 128, 0.5)");
+  });
+
+  it("should throw an error for an hsl color", () => {
+    const color = "hsl(0, 100%, 50%)";
+    const opacity = 0.5;
+    expect(() => setRgbColorOpacity({ color, opacity })).toThrowError("unexpected color format");
+  });
+
+  it("should throw an error for an rgb color with opacity", () => {
+    const color = "rgb(255, 0, 0, 0.2)";
+    const opacity = 0.5;
+    expect(() => setRgbColorOpacity({ color, opacity })).toThrowError("unexpected color format");
+  });
+
+  it("should throw an error for an rgba color without opacity", () => {
+    const color = "rgba(255, 0, 0)";
+    const opacity = 0.5;
+    expect(() => setRgbColorOpacity({ color, opacity })).toThrowError("unexpected color format");
+  });
+});

--- a/other/setRgbColorOpacity.ts
+++ b/other/setRgbColorOpacity.ts
@@ -1,0 +1,19 @@
+const RGB_RE = /^rgb\((\d+), *(\d+), *(\d+)\)$/i;
+const RGBA_RE = /^rgba\((\d+), *(\d+), *(\d+), *\d+(?:\.\d+)?\)$/i;
+
+export function setRgbColorOpacity({ color, opacity }: {
+  color: string;
+  opacity: number;
+}): string {
+  const rgbMatch = color.match(RGB_RE);
+  if (rgbMatch) {
+    return `rgba(${rgbMatch[1]}, ${rgbMatch[2]}, ${rgbMatch[3]}, ${opacity})`;
+  }
+
+  const rgbaMatch = color.match(RGBA_RE);
+  if (!rgbaMatch) {
+    throw new Error("unexpected color format");
+  }
+
+  return `rgba(${rgbaMatch[1]}, ${rgbaMatch[2]}, ${rgbaMatch[3]}, ${opacity})`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@prisma/client": "^5.21.1",
         "argparse": "^2.0.1",
         "bcrypt": "^5.1.1",
+        "chart.js": "^4.4.6",
         "isolated-vm": "^4.6.0",
         "lru-cache": "^10.2.0",
         "pixi.js": "^8.3.4",
@@ -1463,6 +1464,12 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==",
       "license": "MIT"
     },
     "node_modules/@kwsites/file-exists": {
@@ -5515,6 +5522,18 @@
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.6.tgz",
+      "integrity": "sha512-8Y406zevUPbbIBA/HRk33khEmQPk5+cxeflWE/2rx1NJsjVWMPw/9mSP9rxHP5eqi6LNoPBVMfZHxbwLSgldYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/check-error": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@prisma/client": "^5.21.1",
     "argparse": "^2.0.1",
     "bcrypt": "^5.1.1",
+    "chart.js": "^4.4.6",
     "isolated-vm": "^4.6.0",
     "lru-cache": "^10.2.0",
     "pixi.js": "^8.3.4",

--- a/server/api/rating.get.ts
+++ b/server/api/rating.get.ts
@@ -114,6 +114,8 @@ export default defineEventHandler(async () => {
           winnerUserId,
         });
       } else {
+        // create new dynamic stats for earlier hours until we reach an hour
+        // that covers the current game
         let matchingStat = lastDynamicStat;
         do {
           matchingStat = {
@@ -122,6 +124,7 @@ export default defineEventHandler(async () => {
           };
           rawUserStat.scoreDynamic1hour.push(matchingStat);
         } while (matchingStat.intervalEnd.getTime() - game.end_time.getTime() >= ONE_HOUR_MS);
+
         matchingStat.stats = getUpdatedRawStats({
           rawStats: matchingStat.stats,
           stats: stat,
@@ -137,6 +140,9 @@ export default defineEventHandler(async () => {
     const dynamicScores = rawUserStat.scoreDynamic1hour
       .map(dynamicStat => computeScore(dynamicStat.stats))
       .reverse();
+
+    // pad the array with zeros to ensure they are all the same length
+    // and we can graph them easily
     const scoreDynamic1hour = frontPadArrayWithZeros({
       array: dynamicScores,
       targetLength: expectedDynamicStatCount,

--- a/server/api/rating.get.ts
+++ b/server/api/rating.get.ts
@@ -11,12 +11,16 @@ type UserStats = {
   avgEndgameSize: number;
 };
 
-type UserRating = UserStats & {
+export type UserRating = UserStats & {
   userId: number;
   username: string;
   score7days: number;
   score24hours: number;
   score1hour: number;
+  /**
+   * Contains the last 7 days of `score1hour` values.
+   */
+  scoreDynamic1hour: number[];
 };
 
 type RawStats = Omit<UserStats, "avgEndgameSize" | "maxEndgameSize"> & {
@@ -29,7 +33,10 @@ type RawUserStats = {
   stats7days: RawStats;
   stats24hours: RawStats;
   stats1hour: RawStats;
+  scoreDynamic1hour: { intervalEnd: Date; stats: RawStats }[];
 };
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
 
 export default defineEventHandler(async () => {
   const now = new Date();
@@ -52,7 +59,8 @@ export default defineEventHandler(async () => {
 
   const rawUserStats: Record<number, RawUserStats> = {};
 
-  for (const game of games) {
+  const sortedGames = [...games].sort((a, b) => b.start_time.getTime() - a.start_time.getTime());
+  for (const game of sortedGames) {
     const usersBySize = [...game.game_stats].sort((a, b) => b.size - a.size);
     // the winner is the largest user by the end of the game
     // but they shouldn't share the win with other users, otherwise it's a draw
@@ -70,6 +78,7 @@ export default defineEventHandler(async () => {
         stats7days: getEmptyRawStats(),
         stats24hours: getEmptyRawStats(),
         stats1hour: getEmptyRawStats(),
+        scoreDynamic1hour: [{ intervalEnd: now, stats: getEmptyRawStats() }],
       });
 
       rawUserStat.stats7days = getUpdatedRawStats({
@@ -93,10 +102,46 @@ export default defineEventHandler(async () => {
           winnerUserId,
         });
       }
+
+      const lastDynamicStat = rawUserStat.scoreDynamic1hour[rawUserStat.scoreDynamic1hour.length - 1];
+      if (!lastDynamicStat) {
+        throw new Error("lastDynamicStat is undefined");
+      }
+      if (lastDynamicStat.intervalEnd.getTime() - game.end_time.getTime() < ONE_HOUR_MS) {
+        lastDynamicStat.stats = getUpdatedRawStats({
+          rawStats: lastDynamicStat.stats,
+          stats: stat,
+          winnerUserId,
+        });
+      } else {
+        let matchingStat = lastDynamicStat;
+        do {
+          matchingStat = {
+            intervalEnd: new Date(matchingStat.intervalEnd.getTime() - ONE_HOUR_MS),
+            stats: getEmptyRawStats(),
+          };
+          rawUserStat.scoreDynamic1hour.push(matchingStat);
+        } while (matchingStat.intervalEnd.getTime() - game.end_time.getTime() >= ONE_HOUR_MS);
+        matchingStat.stats = getUpdatedRawStats({
+          rawStats: matchingStat.stats,
+          stats: stat,
+          winnerUserId,
+        });
+      }
     }
   }
 
+  const expectedDynamicStatCount = Math.ceil((now.getTime() - oneWeekAgo.getTime()) / ONE_HOUR_MS);
+
   const userRatings: UserRating[] = Object.values(rawUserStats).map((rawUserStat) => {
+    const dynamicScores = rawUserStat.scoreDynamic1hour
+      .map(dynamicStat => computeScore(dynamicStat.stats))
+      .reverse();
+    const scoreDynamic1hour = frontPadArrayWithZeros({
+      array: dynamicScores,
+      targetLength: expectedDynamicStatCount,
+    });
+
     return {
       ...rawUserStat.stats7days,
       userId: rawUserStat.userId,
@@ -109,6 +154,7 @@ export default defineEventHandler(async () => {
       score7days: computeScore(rawUserStat.stats7days),
       score24hours: computeScore(rawUserStat.stats24hours),
       score1hour: computeScore(rawUserStat.stats1hour),
+      scoreDynamic1hour,
     };
   }).sort((a, b) => b.score7days - a.score7days);
 
@@ -147,4 +193,14 @@ function getUpdatedRawStats({ rawStats, stats, winnerUserId }: {
     foodEaten: rawStats.foodEaten + stats.food_eaten,
     endgameSizes: [...rawStats.endgameSizes, stats.size],
   };
+}
+
+function frontPadArrayWithZeros({ array, targetLength }: {
+  array: number[];
+  targetLength: number;
+}) {
+  if (array.length > targetLength) {
+    throw new Error("array.length > targetLength");
+  }
+  return [...new Array(targetLength - array.length).fill(0), ...array];
 }


### PR DESCRIPTION
## How does this PR impact the user?

Merge only after:
- [x] #73 is merged

This PR lets users view the hourly score graph.

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/b60f597c-50e4-4c1c-8785-4753f6a74691">

Loom:
https://www.loom.com/share/0c83f60483e4496db407fb033507708b

## Description

- [x] update `rating.get.ts` to compute the hourly score graph
- [x] add the `RatingChart` to the UI
- [x] add the `setRgbColorOpacity` util with tests to support the `RatingChart`

## Limitations

Depending on how useful this one is, we may want to add other kinds of graphs in the future.

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
