### PR TITLE
feat: add different food sizes, increase food count, add food respawn, and make bots grow proportionally

### DIFF
--- a/other/getRandomElement.spec.ts
+++ b/other/getRandomElement.spec.ts
@@ -5,7 +5,7 @@ it("returns a random element from the array", () => {
   const array = [1, 2, 3, 4, 5];
   const randomElement = getRandomElement(array);
 
-  expect(array).toContain(randomElement);
+  expect(array).toContain(randomElement.element);
 });
 
 it("throws an error if the array is empty", () => {

--- a/other/getRandomElement.ts
+++ b/other/getRandomElement.ts
@@ -1,4 +1,4 @@
-export default function getRandomElement<T>(array: T[]): T {
+export default function getRandomElement<T>(array: T[]): { element: T; idx: number } {
   if (!array.length) {
     throw new Error("Array is empty");
   }
@@ -10,5 +10,5 @@ export default function getRandomElement<T>(array: T[]): T {
   // to generate the random index
   const randomElement = array[randomIndex] as T;
 
-  return randomElement;
+  return { element: randomElement, idx: randomIndex };
 }

--- a/other/world.spec.ts
+++ b/other/world.spec.ts
@@ -34,7 +34,7 @@ it("correctly removes food when the bot eats it", () => {
   bot.y = 10;
 
   // @ts-expect-error - world.food is private
-  expect(world.food.length).toBe(100);
+  expect(world.food.length).toBe(200);
 
   // @ts-expect-error - world.food is private
   const food = world.food[0] as Sprite;
@@ -44,7 +44,7 @@ it("correctly removes food when the bot eats it", () => {
   world.checkCollisions();
 
   // @ts-expect-error - world.food is private
-  expect(world.food.length).toBeLessThan(100);
+  expect(world.food.length).toBeLessThan(200);
 });
 
 it("shouldn't crash when bot eats two food items and one of them with the last index", () => {
@@ -57,7 +57,7 @@ it("shouldn't crash when bot eats two food items and one of them with the last i
   bot.y = 10;
 
   // @ts-expect-error - world.food is private
-  expect(world.food.length).toBe(100);
+  expect(world.food.length).toBe(200);
 
   // @ts-expect-error - world.food is private
   const food1 = world.food[0] as Sprite;
@@ -72,7 +72,7 @@ it("shouldn't crash when bot eats two food items and one of them with the last i
   world.checkCollisions();
 
   // @ts-expect-error - world.food is private
-  expect(world.food.length).toBeLessThan(100);
+  expect(world.food.length).toBeLessThan(200);
 });
 
 it("doesn't allow the bot to go outside the world with large x and y", () => {

--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -8,8 +8,9 @@ const MEMORY_LIMIT_MB = 64;
 const TIME_LIMIT_MS = 75;
 const MAX_ROUND_TIME_MS = 15 * 1000 * 60;
 const GAME_STEP_INTERVAL_MS = 250;
+const WORLD_SIZE = 600;
 
-export const WORLD_REF = { world: new World ({ width: 600, height: 600 }) };
+export const WORLD_REF = { world: new World ({ width: WORLD_SIZE, height: WORLD_SIZE }) };
 
 async function runBot(code: string) {
   const isolate = new ivm.Isolate({ memoryLimit: MEMORY_LIMIT_MB });
@@ -68,6 +69,8 @@ async function runBots({ bots, world, prevBotState, botApi }: RunBotArgs) {
   while (world.checkCollisions() && --collisionCheckLimit) {
     continue;
   }
+
+  world.spawnFood();
 }
 
 type StartEngineArgs = {
@@ -122,7 +125,7 @@ function endGame(reason: string) {
       };
     }).filter((entry): entry is GameStat => entry.userId !== undefined && entry.size !== undefined),
   });
-  WORLD_REF.world = new World ({ width: 600, height: 600 });
+  WORLD_REF.world = new World ({ width: WORLD_SIZE, height: WORLD_SIZE });
 }
 
 export default defineNitroPlugin(async () => {


### PR DESCRIPTION
## How does this PR impact the user?

This PR:
- [x] increases initial food count to 200
- [x] add a 0.5% probability to spawn an extra 25 food every game "step" (with the max limit of 250 food items on the map)
- [x] updates food generation logic to generate food items in 3 sizes, with radiuses of 1, 2, and 3
- [x] updates the bot growth logic to calculate the radius increase based on the area of a circle to make it look more natural

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/202174f3-6de1-4a3b-a724-23f2e91e3297">

## Description

Ditto ⬆️ 

## Limitations

We may need to do some more tuning based on how this works for us 🤷  Excited to see in prod 🚀 

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
