### PR TITLE
fix: ensure that larger bots are always rendered above the smaller ones so that "eating" other bots looks more natural

### DIFF
--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -169,6 +169,19 @@ watch(gameState, async (newState, prevState) => {
         botSpawnsRef.value[bot.spawnId] = graphics;
       }
     }
+
+    // ensure that larger bots are rendered above the smaller ones
+    // this maps better to the metaphor of eating compared to when a smaller
+    // bot is rendered above the larger one
+    const botsSortedByIncreasingRadius = Object.values(prevState.bots)
+      .sort((a, b) => a.radius - b.radius);
+    for (const [index, bot] of botsSortedByIncreasingRadius.entries()) {
+      const existingBot = botSpawnsRef.value[bot.spawnId];
+      if (existingBot) {
+        existingBot.zIndex = index;
+      }
+    }
+    appRef.value.stage.sortChildren();
   }
 
   // slowly move the bots from prevState to newState during the refresh interval


### PR DESCRIPTION
## How does this PR impact the user?

Larger bots will always be rendered above the smaller ones to ensure that "eating" other bots looks natural.

### Before

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/13b03d31-a5a8-4932-9d29-0d56036a78fc">

### After

<img width="1424" alt="Screenshot 2024-11-16 at 10 56 18" src="https://github.com/user-attachments/assets/69bfa649-dd48-4e54-aeba-8998eefee1be">

## Description

Ditto ⬆️ 

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
