### PR TITLE
fix(engine): speed up the code runner (for up to 4.44 times)

### DIFF
--- a/other/CodeRunner.spec.ts
+++ b/other/CodeRunner.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { CodeRunner } from "./CodeRunner";
+
+describe("CodeRunner", () => {
+  it("can run code", async () => {
+    const codeRunner = new CodeRunner();
+    const result = await codeRunner.runCode("1 + 1");
+    expect(result).toEqual(2);
+  });
+
+  it("can return stringified objects", async () => {
+    const codeRunner = new CodeRunner();
+    const result = await codeRunner.runCode("JSON.stringify({ a: 1, b: 2 })");
+    expect(JSON.parse(result)).toEqual({ a: 1, b: 2 });
+  });
+
+  it("can access Math object", async () => {
+    const codeRunner = new CodeRunner();
+    const result = await codeRunner.runCode("Math.sqrt(4)");
+    expect(result).toEqual(2);
+  });
+
+  it("crashes if the code throws an exception", async () => {
+    const codeRunner = new CodeRunner();
+    expect(() => codeRunner.runCode(`(() => { throw Error("I am a test exception") })()`))
+      .rejects
+      .toThrow("I am a test exception");
+  });
+
+  it("can't access the `window` object", async () => {
+    const codeRunner = new CodeRunner();
+    expect(() => codeRunner.runCode("JSON.stringify(window.location)"))
+      .rejects
+      .toThrow("window is not defined");
+  });
+
+  it("crashes if the code consumes too much memory", async () => {
+    const codeRunner = new CodeRunner();
+    expect(() => {
+      return codeRunner.runCode(`
+        const array = new Array(70 * 1024 * 1024 / 4);
+        array.fill(0);
+      `);
+    }).rejects.toThrow("Isolate was disposed during execution due to memory limit");
+  });
+
+  it("crashes if the code runs for too long", async () => {
+    const codeRunner = new CodeRunner();
+    expect(() => codeRunner.runCode("while (true) {}"))
+      .rejects
+      .toThrow("Script execution timed out");
+  });
+});

--- a/other/CodeRunner.ts
+++ b/other/CodeRunner.ts
@@ -1,0 +1,39 @@
+import ivm from "isolated-vm";
+
+export class CodeRunner {
+  private memoryLimitMb = 64;
+  private timeLimitMs = 75;
+  private isolate: ivm.Isolate;
+
+  constructor() {
+    this.isolate = new ivm.Isolate({ memoryLimit: this.memoryLimitMb });
+  }
+
+  dispose() {
+    this.isolate.dispose();
+  }
+
+  async runCode(code: string) {
+    if (this.isolate.isDisposed) {
+      throw new Error("CodeRunner was disposed, create a new instance to run code");
+    }
+
+    let context: ivm.Context | undefined;
+    try {
+      context = await this.isolate.createContext();
+
+      // https://github.com/laverdet/isolated-vm/blob/main/README.md#examples
+      // Get a Reference{} to the global object within the context.
+      const jail = context.global;
+      // This makes the global object available in the context as `global`. We use `derefInto()` here
+      // because otherwise `global` would actually be a Reference{} object in the new isolate.
+      await jail.set("global", jail.derefInto());
+
+      const result = await context.eval(code, { timeout: this.timeLimitMs });
+      return result;
+    } finally {
+      // always release the context to avoid memory leaks
+      context?.release();
+    }
+  }
+}

--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -1,24 +1,18 @@
-import ivm from "isolated-vm";
 import prepareBotCode from "~/other/prepareBotCode";
 import * as botCodeStore from "~/other/botCodeStore";
 import World, { type WorldState } from "~/other/world";
 import { recordGameEnd, type GameStat } from "~/other/recordGamedb";
+import { CodeRunner } from "~/other/CodeRunner";
 
-const MEMORY_LIMIT_MB = 64;
-const TIME_LIMIT_MS = 75;
 const MAX_ROUND_TIME_MS = 15 * 1000 * 60;
 const GAME_STEP_INTERVAL_MS = 250;
 const WORLD_SIZE = 600;
 
 export const WORLD_REF = { world: new World ({ width: WORLD_SIZE, height: WORLD_SIZE }) };
+const codeRunner = new CodeRunner();
 
 async function runBot(code: string) {
-  const isolate = new ivm.Isolate({ memoryLimit: MEMORY_LIMIT_MB });
-  const context = await isolate.createContext();
-  const jail = context.global;
-  await jail.set("global", jail.derefInto());
-  const result = await context.eval(code, { timeout: TIME_LIMIT_MS });
-  isolate.dispose();
+  const result = await codeRunner.runCode(code);
   return JSON.parse(result);
 }
 


### PR DESCRIPTION
## How does this PR impact the user?

If the speed improvement is enough, this PR will eliminate a weird bot lag movement we are seeing on prod from time to time.

## Description

- [x] move the code runner login into the `CodeRunner` class
- [x] add tests for the `CodeRunner` class
- [x] ensure we always release the execution `context` even if the bot crashed
- [x] ensure we create only a single isolate (for the whole app) instead of what we were doing before when we were creating an isolate per code execution 😱 

### Before: average execution time of the `({ a: 1, b: 2 })` script was 1.081ms on M1 Max 😱 

<img width="477" alt="Screenshot 2024-11-16 at 14 04 16" src="https://github.com/user-attachments/assets/4d057485-1532-4249-8232-16f29fef6f7b">

#### After: average execution time of the `({ a: 1, b: 2 })` script became 0.243ms on M1 Max 🚀 (x4.4 times faster)

<img width="412" alt="Screenshot 2024-11-16 at 14 11 58" src="https://github.com/user-attachments/assets/74087a8f-bd37-459a-9d26-5f435e244e5b">

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
