### PR TITLE
test(CodeRunner): ensure user's code can't call `fetch` and modify prototypes

### DIFF
--- a/other/CodeRunner.spec.ts
+++ b/other/CodeRunner.spec.ts
@@ -59,4 +59,21 @@ describe("CodeRunner", () => {
       .rejects
       .toThrow("a is not defined");
   });
+
+  it("can't call `fetch`", async () => {
+    const codeRunner = new CodeRunner();
+    expect(() => codeRunner.runCode("fetch('https://example.com')"))
+      .rejects
+      .toThrow("fetch is not defined");
+  });
+
+  it("modifications to the `Array` prototype don't leak between runs and outside of an isolate", async () => {
+    const codeRunner = new CodeRunner();
+    const result1 = await codeRunner.runCode("Array.prototype.foo = 42; [].foo");
+    expect(result1).toBe(42);
+    const result2 = await codeRunner.runCode("[].foo");
+    expect(result2).toBeUndefined();
+    // @ts-expect-error - we're testing a property that doesn't exist on the Array prototype
+    expect([].foo).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## How does this PR impact the user?

No immediate impact.

`CodeRunner` will be less likely to regress.

## Description

- [x] add a "can't call `fetch`" to the `CodeRunner.spec.ts`
- [x] add a "modifications to the `Array` prototype don't leak between runs and outside of an isolate" to the `CodeRunner.spec.ts`

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
