### PR TITLE
feat: zoom in on the game screen to show the players bot more closely and panning on game screen with mouse drag

### DIFF
--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -196,9 +196,6 @@ watch(gameState, async (newState, prevState) => {
     let isDragging = false;
     let startDragPos = { x: 0, y: 0 };
 
-    const mapWidth = 1000; // Replace with actual map width
-    const mapHeight = 1000; // Replace with actual map height
-
     canvas.value?.addEventListener("mousedown", (event) => {
       isDragging = true;
       startDragPos = { x: event.offsetX, y: event.offsetY };
@@ -212,8 +209,8 @@ watch(gameState, async (newState, prevState) => {
         const newPosY = app.stage.position.y + dy;
 
         // Constrain the new position to within map boundaries
-        app.stage.position.x = Math.min(0, Math.max(newPosX, canvas.value.width - mapWidth * app.stage.scale.x));
-        app.stage.position.y = Math.min(0, Math.max(newPosY, canvas.value.height - mapHeight * app.stage.scale.y));
+        app.stage.position.x = Math.min(0, Math.max(newPosX, app.screen.width - app.screen.width * app.stage.scale.x));
+        app.stage.position.y = Math.min(0, Math.max(newPosY, app.screen.height - app.screen.height * app.stage.scale.y));
 
         startDragPos = { x: event.offsetX, y: event.offsetY };
       }

--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -138,26 +138,34 @@ watch(gameState, async (newState, prevState) => {
     let isDragging = false;
     let startDragPos = { x: 0, y: 0 };
 
-    canvas.value.addEventListener("mousedown", (event) => {
+    const mapWidth = 1000; // Replace with actual map width
+    const mapHeight = 1000; // Replace with actual map height
+
+    canvas.value?.addEventListener("mousedown", (event) => {
       isDragging = true;
       startDragPos = { x: event.offsetX, y: event.offsetY };
     });
 
-    canvas.value.addEventListener("mousemove", (event) => {
-      if (isDragging) {
+    canvas.value?.addEventListener("mousemove", (event) => {
+      if (isDragging && canvas.value) {
         const dx = event.offsetX - startDragPos.x;
         const dy = event.offsetY - startDragPos.y;
-        app.stage.position.x += dx;
-        app.stage.position.y += dy;
+        const newPosX = app.stage.position.x + dx;
+        const newPosY = app.stage.position.y + dy;
+
+        // Constrain the new position to within map boundaries
+        app.stage.position.x = Math.min(0, Math.max(newPosX, canvas.value.width - mapWidth * app.stage.scale.x));
+        app.stage.position.y = Math.min(0, Math.max(newPosY, canvas.value.height - mapHeight * app.stage.scale.y));
+
         startDragPos = { x: event.offsetX, y: event.offsetY };
       }
     });
 
-    canvas.value.addEventListener("mouseup", () => {
+    canvas.value?.addEventListener("mouseup", () => {
       isDragging = false;
     });
 
-    canvas.value.addEventListener("mouseleave", () => {
+    canvas.value?.addEventListener("mouseleave", () => {
       isDragging = false;
     });
 

--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -23,6 +23,7 @@ const canvas = ref<HTMLCanvasElement | null>(null);
 const appRef = ref<Application | null>(null);
 const foodRef = ref<{ x: number; y: number; graphics: Graphics }[]>([]);
 const botSpawnsRef = ref<Record<string, Graphics>>({});
+const gameScreen = ref<HTMLDivElement | null>(null);
 
 const tickFnRef = ref<() => void>();
 
@@ -188,6 +189,11 @@ watch(gameState, async (newState, prevState) => {
           Math.min(0, Math.max(app.stage.position.x - (newScreenPos.x - mousePos.x), app.screen.width - app.screen.width * newScale)),
           Math.min(0, Math.max(app.stage.position.y - (newScreenPos.y - mousePos.y), app.screen.height - app.screen.height * newScale)),
         );
+        if (newScale > 1) {
+          gameScreen.value?.classList.add("cursor-grab");
+        } else {
+          gameScreen.value?.classList.remove("cursor-grab");
+        }
       }
     });
 
@@ -196,6 +202,9 @@ watch(gameState, async (newState, prevState) => {
     let startDragPos = { x: 0, y: 0 };
 
     canvas.value?.addEventListener("mousedown", (event) => {
+      if (app.stage.scale.x > 1) {
+        gameScreen.value?.classList.add("cursor-grabbing");
+      }
       isDragging = true;
       startDragPos = { x: event.offsetX, y: event.offsetY };
     });
@@ -216,10 +225,12 @@ watch(gameState, async (newState, prevState) => {
     });
 
     canvas.value?.addEventListener("mouseup", () => {
+      gameScreen.value?.classList.remove("cursor-grabbing");
       isDragging = false;
     });
 
     canvas.value?.addEventListener("mouseleave", () => {
+      gameScreen.value?.classList.remove("cursor-grabbing");
       isDragging = false;
     });
 
@@ -329,6 +340,7 @@ watch(gameState, async (newState, prevState) => {
     data-testid="game-screen"
   >
     <div
+      ref="gameScreen"
       class="flex flex-col shadow ml-2"
       :style="{ maxWidth: gameState?.width + 'px' }"
     >

--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -159,7 +159,7 @@ watch(gameState, async (newState, prevState) => {
       }
     }
 
-    // Update the mouse wheel event listener
+    // Mouse wheel event listener
     canvas.value?.addEventListener("wheel", (event) => {
       event.preventDefault();
       const mousePos = { x: event.offsetX, y: event.offsetY };

--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -160,6 +160,8 @@ watch(gameState, async (newState, prevState) => {
     }
 
     // Mouse wheel event listener
+    // Event listeners can be potentially called multiple times.
+    // TODO: add .removeEventListener later for refactoring.
     canvas.value?.addEventListener("wheel", (event) => {
       event.preventDefault();
       const mousePos = { x: event.offsetX, y: event.offsetY };

--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -148,10 +148,9 @@ watch(gameState, async (newState, prevState) => {
       };
 
       appRef.value.stage.position.set(
-        appRef.value.stage.position.x - (newScreenPos.x - startMousePos.x),
-        appRef.value.stage.position.y - (newScreenPos.y - startMousePos.y),
+        Math.min(0, Math.max(appRef.value.stage.position.x - (newScreenPos.x - startMousePos.x), appRef.value.screen.width - appRef.value.screen.width * newScale)),
+        Math.min(0, Math.max(appRef.value.stage.position.y - (newScreenPos.y - startMousePos.y), appRef.value.screen.height - appRef.value.screen.height * newScale)),
       );
-
       if (progress < 1) {
         requestAnimationFrame(animateZoomOut);
       } else {
@@ -186,8 +185,8 @@ watch(gameState, async (newState, prevState) => {
         };
 
         app.stage.position.set(
-          app.stage.position.x - (newScreenPos.x - mousePos.x),
-          app.stage.position.y - (newScreenPos.y - mousePos.y),
+          Math.min(0, Math.max(app.stage.position.x - (newScreenPos.x - mousePos.x), app.screen.width - app.screen.width * newScale)),
+          Math.min(0, Math.max(app.stage.position.y - (newScreenPos.y - mousePos.y), app.screen.height - app.screen.height * newScale)),
         );
       }
     });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,10 +9,7 @@ export default {
     "./error.vue",
   ],
   theme: {
-    extend: {
-      cursor: {
-      },
-    },
+    extend: {},
   },
   plugins: [],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,10 @@ export default {
     "./error.vue",
   ],
   theme: {
-    extend: {},
+    extend: {
+      cursor: {
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->
![Recording 2024-11-22 at 12 06 16](https://github.com/user-attachments/assets/c4017c94-6487-4656-9f79-3cfeaf12ab76)

## Description
<!-- Concisely describe the changes in this PR -->
- Issue #48
- Allows users to zoom in in the game screen using mouse wheel on the mouse location.
- Allows user to pan through the game screen with mouse dragging.
- Max zoom in is 3 times.

## Limitations
<!-- Anything related to this PR that wasn't "done" in this PR -->
- Currently panning outside the predefined spawn locations of the food doesn't look good.
- Same issue with zooming out

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
