### PR TITLE
perf: speedup world.getAvailableSpawnPositions and world.spawnFood with it

### DIFF
--- a/other/world.spec.ts
+++ b/other/world.spec.ts
@@ -195,6 +195,18 @@ describe(".deserializePosition", () => {
 });
 
 describe(".getAvailableSpawnPositions", () => {
+  it("returns all available positions if there are no bots", () => {
+    const worldSize = 100;
+
+    const world = new World({ width: worldSize, height: worldSize });
+
+    const newEntityRadius = 1;
+    // @ts-expect-error - world.getAvailableSpawnPositions is private
+    const availablePositions = world.getAvailableSpawnPositions(newEntityRadius);
+    // we step away from the walls by the radius of the new entity
+    expect(availablePositions.length).toEqual((worldSize - newEntityRadius * 2) * (worldSize - newEntityRadius * 2));
+  });
+
   it("returns fewer positions than there are on the grid because bot occupy some", () => {
     const worldSize = 100;
 
@@ -205,10 +217,10 @@ describe(".getAvailableSpawnPositions", () => {
     // @ts-expect-error - world.getAvailableSpawnPositions is private
     const availablePositions = world.getAvailableSpawnPositions(newEntityRadius);
     // we step away from the walls by the radius of the new entity
-    expect(availablePositions.length).toBeLessThan((worldSize - newEntityRadius) * (worldSize - newEntityRadius));
+    expect(availablePositions.length).toBeLessThan((worldSize - newEntityRadius * 2) * (worldSize - newEntityRadius * 2));
   });
 
-  it("doesn't return nullish elements", () => {
+  it("doesn't return nullish elements when there is a bot", () => {
     const worldSize = 100;
 
     const world = new World({ width: worldSize, height: worldSize });
@@ -217,6 +229,14 @@ describe(".getAvailableSpawnPositions", () => {
     const newEntityRadius = 1;
     // @ts-expect-error - world.getAvailableSpawnPositions is private
     const availablePositions = world.getAvailableSpawnPositions(newEntityRadius);
-    expect(availablePositions.every(Boolean)).toBe(true);
+    expect([...availablePositions].every(Boolean)).toBe(true);
+  });
+
+  it("doesn't return nullish elements when there are no bots", () => {
+    const world = new World({ width: 100, height: 100 });
+    const newEntityRadius = 1;
+    // @ts-expect-error - world.getAvailableSpawnPositions is private
+    const availablePositions = world.getAvailableSpawnPositions(newEntityRadius);
+    expect([...availablePositions].every(Boolean)).toBe(true);
   });
 });

--- a/other/world.spec.ts
+++ b/other/world.spec.ts
@@ -195,18 +195,6 @@ describe(".deserializePosition", () => {
 });
 
 describe(".getAvailableSpawnPositions", () => {
-  it("returns all available positions if there are no bots", () => {
-    const worldSize = 100;
-
-    const world = new World({ width: worldSize, height: worldSize });
-
-    const newEntityRadius = 1;
-    // @ts-expect-error - world.getAvailableSpawnPositions is private
-    const availablePositions = world.getAvailableSpawnPositions(newEntityRadius);
-    // we step away from the walls by the radius of the new entity
-    expect(availablePositions.length).toEqual((worldSize - newEntityRadius * 2) * (worldSize - newEntityRadius * 2));
-  });
-
   it("returns fewer positions than there are on the grid because bot occupy some", () => {
     const worldSize = 100;
 
@@ -217,10 +205,10 @@ describe(".getAvailableSpawnPositions", () => {
     // @ts-expect-error - world.getAvailableSpawnPositions is private
     const availablePositions = world.getAvailableSpawnPositions(newEntityRadius);
     // we step away from the walls by the radius of the new entity
-    expect(availablePositions.length).toBeLessThan((worldSize - newEntityRadius * 2) * (worldSize - newEntityRadius * 2));
+    expect(availablePositions.length).toBeLessThan((worldSize - newEntityRadius) * (worldSize - newEntityRadius));
   });
 
-  it("doesn't return nullish elements when there is a bot", () => {
+  it("doesn't return nullish elements", () => {
     const worldSize = 100;
 
     const world = new World({ width: worldSize, height: worldSize });
@@ -229,14 +217,6 @@ describe(".getAvailableSpawnPositions", () => {
     const newEntityRadius = 1;
     // @ts-expect-error - world.getAvailableSpawnPositions is private
     const availablePositions = world.getAvailableSpawnPositions(newEntityRadius);
-    expect([...availablePositions].every(Boolean)).toBe(true);
-  });
-
-  it("doesn't return nullish elements when there are no bots", () => {
-    const world = new World({ width: 100, height: 100 });
-    const newEntityRadius = 1;
-    // @ts-expect-error - world.getAvailableSpawnPositions is private
-    const availablePositions = world.getAvailableSpawnPositions(newEntityRadius);
-    expect([...availablePositions].every(Boolean)).toBe(true);
+    expect(availablePositions.every(Boolean)).toBe(true);
   });
 });

--- a/other/world.ts
+++ b/other/world.ts
@@ -130,13 +130,12 @@ export default class World {
     const minY = newEntityRadius;
     const maxY = this.height - newEntityRadius;
 
-    const availablePositions: number[] = new Array(this.height * this.width - takenPositions.size);
-    let availablePositionsIdx = 0;
+    const availablePositions: number[] = [];
     for (let i = minX; i < maxX; i++) {
       for (let j = minY; j < maxY; j++) {
         const serializedPosition = World.serializePosition({ x: i, y: j });
         if (!takenPositions.has(serializedPosition)) {
-          availablePositions[availablePositionsIdx++] = serializedPosition;
+          availablePositions.push(serializedPosition);
         }
       }
     }

--- a/other/world.ts
+++ b/other/world.ts
@@ -130,15 +130,22 @@ export default class World {
     const minY = newEntityRadius;
     const maxY = this.height - newEntityRadius;
 
-    const availablePositions: number[] = [];
+    const availablePositions: number[] = new Array(this.height * this.width - takenPositions.size);
+    let availablePositionsIdx = 0;
     for (let i = minX; i < maxX; i++) {
       for (let j = minY; j < maxY; j++) {
         const serializedPosition = World.serializePosition({ x: i, y: j });
         if (!takenPositions.has(serializedPosition)) {
-          availablePositions.push(serializedPosition);
+          availablePositions[availablePositionsIdx++] = serializedPosition;
         }
       }
     }
+
+    // trim any undefined elements at the end
+    // we may have them because when preallocating the array we subtracted the `takenPosition.size`,
+    // but not the border padding of `newEntityRadius`
+    const lastNumberIdx = availablePositions.findLastIndex(pos => pos !== undefined);
+    availablePositions.length = lastNumberIdx + 1;
 
     return availablePositions;
   }


### PR DESCRIPTION
## How does this PR impact the user?

The game will lag less.

### Before

<img width="582" alt="Screenshot 2024-11-30 at 21 00 06" src="https://github.com/user-attachments/assets/ebab669e-c59f-40e1-9718-50af28802521">

### Now (7x speedup)

<img width="571" alt="Screenshot 2024-11-30 at 21 22 59" src="https://github.com/user-attachments/assets/89aebbde-c6d6-4342-83ab-a6d62934fdda">

## Description

- [x] update the `getAvailableSpawnPositions` use positions serialized to a `number` instead of `string` in the `takenPositions` set
- [x] update the `getAvailableSpawnPositions` to return an array of positions serialized to a `number` instead of position objects – stop create objects for every position, this was **very** expensive
- [x] update the `getAvailableSpawnPositions` to pre-allocate space for the `availablePositions` array
- [x] add tests for the changes made

## Limitations

It is def not the most optimized version of this algorithm. We can return to it when we see issues with it.

## Checklist

- [x] my PR is focused and contains one wholistic change
- [x] I have added screenshots or screen recordings to show the changes
