### PR TITLE
feat: increase speed for small, and decrease speed for big bots

### DIFF
--- a/other/world.ts
+++ b/other/world.ts
@@ -108,10 +108,8 @@ export default class World {
   }
 
   private getMaxBotMoveDistance(radius: number): number {
-    const rawSpeed = 1 / Math.pow(radius, this.moveDistanceChangePow);
-    const rawMax = 1 / Math.pow(this.newBotRadius, this.moveDistanceChangePow);
-
-    const normalizedSpeed = (rawSpeed / rawMax) * this.maxMoveDistance;
+    const speedRatio = Math.pow(this.newBotRadius / radius, this.moveDistanceChangePow);
+    const normalizedSpeed = speedRatio * this.maxMoveDistance;
     return Math.max(this.minMoveDistance, normalizedSpeed);
   }
 

--- a/other/world.ts
+++ b/other/world.ts
@@ -57,7 +57,9 @@ export default class World {
   private width: number;
   private height: number;
   private minSpawnDistance = 10;
-  private maxMoveDistance = 2;
+  private minMoveDistance = 2;
+  private maxMoveDistance = 9;
+  private moveDistanceChangePow = 0.45;
   private newBotRadius = 5;
   private maxFoodRadius = 3;
   private initialFoodCount = 200;
@@ -103,6 +105,14 @@ export default class World {
     const x = serializedPosition & 0xFFFF;
     const y = (serializedPosition >> 16) & 0xFFFF;
     return { x, y };
+  }
+
+  private getMaxBotMoveDistance(radius: number): number {
+    const rawSpeed = 1 / Math.pow(radius, this.moveDistanceChangePow);
+    const rawMax = 1 / Math.pow(this.newBotRadius, this.moveDistanceChangePow);
+
+    const normalizedSpeed = (rawSpeed / rawMax) * this.maxMoveDistance;
+    return Math.max(this.minMoveDistance, normalizedSpeed);
   }
 
   private getAvailableSpawnPositions(newEntityRadius: number): number[] {
@@ -235,10 +245,12 @@ export default class World {
       throw new Error(`Bot with id ${botId} not found`);
     }
 
+    const maxBotMoveDistance = this.getMaxBotMoveDistance(bot.radius);
+
     const distance = World.distance(bot, { x, y });
-    if (distance > this.maxMoveDistance) {
+    if (distance > maxBotMoveDistance) {
       // compute closest possible x and y
-      const { x: newX, y: newY } = World.computeClosestXYWithinDistance(bot, { x, y }, this.maxMoveDistance);
+      const { x: newX, y: newY } = World.computeClosestXYWithinDistance(bot, { x, y }, maxBotMoveDistance);
       x = newX;
       y = newY;
     }


### PR DESCRIPTION
## How does this PR impact the user?
https://github.com/user-attachments/assets/81bbe3a7-d674-49f4-b877-1c3518309d5e

https://github.com/user-attachments/assets/2619b75c-ebc0-4a05-88bf-50a87c83fa05

## Description

This PR introduces a method to dynamically calculate a bot's maximum movement distance (`maxBotMoveDistance`) based on its radius. Instead of relying on a fixed movement distance, the calculation now considers the bot's size using the new `getMaxBotMoveDistance` method.

Key changes:
1. **New parameters**:
   - `moveDistanceChangePow`: Introduced to define the scaling power for movement distance (set to 0.45).
   - Increased `maxMoveDistance` from 2 to 9 for greater flexibility.
2. **New method**:
   - `getMaxBotMoveDistance(radius: number)`: Calculates the maximum movement distance for a bot using its radius, ensuring proportional scaling.
3. **Movement logic update**:
   - Movement checks now use the dynamically calculated `maxBotMoveDistance` instead of a static value.
   - Updated calls to `computeClosestXYWithinDistance` to use the calculated value for more precise movement.

These updates provide more realistic and size-dependent movement for bots.

## Limitations
 - The PR does not include passing the calculated speed to the "step"

## Checklist

- [x] My PR is focused and contains one holistic change.
- [x] I have added screenshots or screen recordings to show the changes.
