### PR TITLE
[Aider 0.75.2] [DeepSeek-r1] [$0.0092] [🔴 doesn't work] feat: persist splitter position in localStorage between page reloads

### DIFF
--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -401,7 +401,7 @@ watch(gameState, async (newState, prevState) => {
 
 <template>
   <div
-    class="h-full w-full"
+    class="h-full w-full game-screen"
     data-testid="game-screen"
   >
     <div


### PR DESCRIPTION
## How does this PR impact the user?

Related to #116.

## Description

This PR was created by `aider` ran with:

```sh
aider --model deepseek/deepseek-reasoner --yes-always
```

Prompt:
> Please, solve the following issue. Title: feat: draggable splitter between the code and the game screen should remember its position between the page reloads. Description: Let's persist it in the localStorage.

Cost: $0.0092 USD.

## Notes

Why did it fail?
- Identified the wrong files to edit.

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/652b9111-00a5-4308-8dbc-27c8e639deeb" />

## Checklist

- [x] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
