### PR TITLE
[Aider] [DeepSeek-r1] feat: make game screen responsive to fill available space

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .game-editor-container {
+    @apply flex flex-row h-[calc(100vh-4rem)] min-h-0;
+  }
+  .code-editor-container {
+    @apply flex-1 min-w-0;
+  }
+}
+
 @layer base {
   @font-face {
     font-family: 'Retropix';

--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -401,13 +401,12 @@ watch(gameState, async (newState, prevState) => {
 
 <template>
   <div
-    class="h-full w-full"
+    class="flex-1 min-w-0"
     data-testid="game-screen"
   >
     <div
       ref="gameScreen"
-      class="flex flex-col shadow ml-2"
-      :style="{ maxWidth: gameState?.width + 'px' }"
+      class="flex flex-col h-full shadow ml-2"
     >
       <div class="flex flex-row justify-end mb-2 mt-1 mx-4 gap-6">
         <ButtonLink
@@ -417,7 +416,7 @@ watch(gameState, async (newState, prevState) => {
           {{ isFollowing ? "stop following my bot" : "follow my bot" }}
         </ButtonLink>
       </div>
-      <canvas ref="canvas" />
+      <canvas ref="canvas" class="flex-1 w-full h-full" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model deepseek/deepseek-reasoner --yes-always
```

Prompt:
> Please, solve the following issue. Title: feat: ensure that the game screen occupies all available free space to the right of the code editor. Description: The game screen should scale and occupy the available free space to the right of the code editor.

Cost: $0.0079 USD.

## Limitations

<!-- Anything related to this PR that wasn't "done" in this PR -->

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
