### PR TITLE
[Aider 0.75.2] [DeepSeek-r1] [$0.02] [🔴 doesn't work] feat: add debug mode toggle to replace sprites with circles

### DIFF
--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -3,6 +3,7 @@ import { Application, Graphics, Text, FillGradient, Assets, type Texture, Sprite
 import { getSmoothZoomScreen, followPlayerBot, getZoomScale } from "~/other/zoomUtils";
 
 const { data: user } = await useFetch("/api/auth/user");
+const debugMode = useLocalStorage("debugMode", false);
 const refreshIntervalMs = 1000;
 const zoomSpeed = 0.1;
 const minZoom = 1;
@@ -96,7 +97,15 @@ function setUsernamePosition({
 }
 
 async function drawBot({ bot, graphics, botDirection }: DrawBotArgs) {
-  if (graphics.children.length > 0) {
+  if (debugMode.value) {
+    // Debug mode - draw simple circle
+    graphics.clear();
+    graphics.beginPath();
+    graphics.arc(bot.x, bot.y, bot.radius, 0, 2 * Math.PI);
+    graphics.fill(bot.color);
+  }
+
+  if (graphics.children.length > 0 && !debugMode.value) {
     const sprite = graphics.children.find(child => child instanceof Sprite);
     const username = graphics.children.find(child => child instanceof Text);
     if (!sprite || !username) {
@@ -415,6 +424,11 @@ watch(gameState, async (newState, prevState) => {
           @click="toggleFollowMeMode"
         >
           {{ isFollowing ? "stop following my bot" : "follow my bot" }}
+        </ButtonLink>
+        <ButtonLink
+          @click="debugMode = !debugMode"
+        >
+          {{ debugMode ? 'normal view' : 'debug view' }}
         </ButtonLink>
       </div>
       <canvas ref="canvas" />

--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -119,6 +119,8 @@ async function drawBot({ bot, graphics, botDirection }: DrawBotArgs) {
   // draw bot
   const usernameHash = bot.username.charCodeAt(0) + (bot.username.charCodeAt(1) || 0) + (bot.username.charCodeAt(2) || 0);
   const numOfSprite = usernameHash % (fishTexturesRef.value.length);
+  if (debugMode.value) return;
+  
   const fishTexture = fishTexturesRef.value[numOfSprite];
   if (!fishTexture) {
     throw new Error("Fish sprite is not loaded");


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model deepseek/deepseek-reasoner --yes-always
```

Prompt:
> Please, solve the following issue. Title: feat(sandbox): add an option to turn off sprites and replace them with circles to make debugging easier. Description: It would be helpful to have a toggle that replaces fish sprites on the Game Screen with circles to avoid getting distracted by uneven sprite shapes when debugging.

Cost: $0.02 USD.

## Notes

The direction isn't bad, but the solution doesn't work.

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/e0cb1721-a1e2-4192-bd13-b06e6ce465de" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
