### PR TITLE
[Aider 0.75.2] [DeepSeek-r1] [$0.01] [🔴 doesn't work] feat: add code version history with restore functionality

### DIFF
--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -33,6 +33,8 @@ const state = reactive({
   code: user.value?.body.code || defaultCode,
   codeHasErrors: false,
   showAPIReference: false,
+  showVersionHistory: false,
+  selectedVersion: null as string | null,
 });
 
 function onSubmit(event: Event) {
@@ -50,6 +52,10 @@ function onRestoreDefaultCodeClick() {
   state.code = defaultCode;
 }
 
+async function onShowVersionHistoryClick() {
+  state.showVersionHistory = true;
+}
+
 function onShowAPIReferenceClick() {
   state.showAPIReference = true;
 }
@@ -64,6 +70,16 @@ function onCloseAPIReferenceModal() {
     class="w-full h-full font-sans flex flex-col"
     data-testid="code-editor"
   >
+    <ModalDialog
+      :open="state.showVersionHistory"
+      :on-close="() => state.showVersionHistory = false"
+      extra-modal-class="w-[800px] h-[600px]"
+    >
+      <CodeVersionHistory 
+        @restore="(code: string) => { state.code = code; }"
+        @close="() => { state.showVersionHistory = false; }"
+      />
+    </ModalDialog>
     <form
       class="flex flex-grow flex-col"
       @submit="onSubmit"
@@ -72,6 +88,9 @@ function onCloseAPIReferenceModal() {
         <div class="flex flex-row justify-end mb-2 mt-1 mx-2 gap-6">
           <ButtonLink @click="onRestoreDefaultCodeClick">
             restore example code
+          </ButtonLink>
+          <ButtonLink @click="onShowVersionHistoryClick">
+            version history
           </ButtonLink>
           <ButtonLink @click="onShowAPIReferenceClick">
             API reference

--- a/components/CodeVersionHistory.vue
+++ b/components/CodeVersionHistory.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { getBotVersions } from "~/other/botCodeStore";
+
+const { data: user } = await useFetch("/api/auth/user");
+const versions = ref<Array<{timestamp: number; code: string}>>([]);
+const selectedCode = ref("");
+const selectedTimestamp = ref<number | null>(null);
+
+onMounted(async () => {
+  if (user.value?.body.id) {
+    versions.value = getBotVersions(user.value.body.id);
+  }
+});
+
+function selectVersion(version: {timestamp: number; code: string}) {
+  selectedCode.value = version.code;
+  selectedTimestamp.value = version.timestamp;
+}
+
+function formatDate(timestamp: number) {
+  return new Date(timestamp).toLocaleString();
+}
+
+const emit = defineEmits(['restore', 'close']);
+
+function onRestore() {
+  emit('restore', selectedCode.value);
+  emit('close');
+}
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+    <h2 class="text-xl font-bold mb-4">Code Version History</h2>
+    <div class="flex flex-grow gap-4">
+      <div class="w-2/3">
+        <MonacoEditor
+          v-model="selectedCode"
+          lang="javascript"
+          :options="{
+            readOnly: true,
+            minimap: { enabled: false },
+            lineNumbers: 'off'
+          }"
+          class="h-full border rounded"
+        />
+      </div>
+      <div class="w-1/3 overflow-y-auto">
+        <div 
+          v-for="version in versions"
+          :key="version.timestamp"
+          @click="selectVersion(version)"
+          class="p-2 border-b cursor-pointer hover:bg-gray-50"
+          :class="{ 'bg-blue-50': selectedTimestamp === version.timestamp }"
+        >
+          <div class="font-medium">{{ formatDate(version.timestamp) }}</div>
+          <div class="text-sm text-gray-500">
+            {{ version.code.slice(0, 40) }}...
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="flex justify-end gap-2 mt-4">
+      <button
+        @click="$emit('close')"
+        class="px-4 py-2 border rounded hover:bg-gray-50"
+      >
+        Cancel
+      </button>
+      <button
+        @click="onRestore"
+        class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        :disabled="!selectedTimestamp"
+      >
+        Restore Version
+      </button>
+    </div>
+  </div>
+</template>

--- a/server/api/bot/submit.post.ts
+++ b/server/api/bot/submit.post.ts
@@ -6,6 +6,7 @@ import { SUBMIT_COOLDOWN_MS } from "~/other/submitApiRatelimitConstants";
 
 const submitBotCodeSchema = z.object({
   code: z.string(),
+  timestamp: z.number().default(Date.now),
 });
 
 const RATELIMITER = new LRUCache<string, boolean>({
@@ -32,6 +33,7 @@ export default defineEventHandler(async (event) => {
     username: event.context.user.username,
     userId: event.context.user.id,
     code: result.data.code,
+    timestamp: result.data.timestamp,
   });
 
   RATELIMITER.set(event.context.user.id, true);


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model deepseek/deepseek-reasoner --yes-always
```

Prompt:
> Please, solve the following issue. Title: feat: add code versions and an option to revert to a previous version. Description: **Goal:** let the user revert to the previous code version
> Proposed implementation:
> - every time the user submits code, store it separately, don't overwrite the previous code version
>     - we can use filenames with dates in them, for example: `<userid>-<timestamp>.js`
>     - use a special name, like `<userid>-latest.js` for the latest code version so we can quickly retrieve it by path
> - add a modal that will allow the user to view previous submissions in the UI and revert to them
>     - the button to open a modal should be above the code editor
>     - the modal left side should be occupied by the read-only code editor
>     - the modal on the right side should be occupied by the list of versions
>     - user can click any of the versions to preview them in the modal
>     - user can click the restore button to restore the version
>     - restoring the code doesn't create a new version until the user submits the code again
> Let me know if you want to work on this ticket and if you have any questions!

Cost: $0.01 USD.

## Notes

The direction kind of makes sense, but it made a few mistakes, including trying to read files from the server filesystem from the frontend.

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/cdbfe3d9-211b-44f0-9f6a-17c7a978df57" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
