### PR TITLE
[Aider] [Claude 3.7] [$0.12] feat: Add draggable splitter with localStorage position persistence

### DIFF
--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -406,7 +406,7 @@ watch(gameState, async (newState, prevState) => {
   >
     <div
       ref="gameScreen"
-      class="flex flex-col shadow ml-2"
+      class="flex flex-col shadow"
       :style="{ maxWidth: gameState?.width + 'px' }"
     >
       <div class="flex flex-row justify-end mb-2 mt-1 mx-4 gap-6">

--- a/components/SplitPane.vue
+++ b/components/SplitPane.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+
+const props = defineProps({
+  initialSplit: {
+    type: Number,
+    default: 50
+  },
+  minLeft: {
+    type: Number,
+    default: 20
+  },
+  minRight: {
+    type: Number,
+    default: 20
+  },
+  storageKey: {
+    type: String,
+    default: 'split-pane-position'
+  }
+});
+
+const container = ref<HTMLDivElement | null>(null);
+const splitter = ref<HTMLDivElement | null>(null);
+const leftPane = ref<HTMLDivElement | null>(null);
+const rightPane = ref<HTMLDivElement | null>(null);
+const splitPercentage = ref(props.initialSplit);
+const isDragging = ref(false);
+
+// Load saved position from localStorage
+onMounted(() => {
+  const savedPosition = localStorage.getItem(props.storageKey);
+  if (savedPosition) {
+    splitPercentage.value = parseFloat(savedPosition);
+  }
+  updateSplit();
+});
+
+// Save position to localStorage when it changes
+watch(splitPercentage, (newValue) => {
+  localStorage.setItem(props.storageKey, newValue.toString());
+});
+
+function updateSplit() {
+  if (!leftPane.value || !rightPane.value) return;
+  
+  leftPane.value.style.width = `${splitPercentage.value}%`;
+  rightPane.value.style.width = `${100 - splitPercentage.value}%`;
+}
+
+function onMouseDown(e: MouseEvent) {
+  isDragging.value = true;
+  document.addEventListener('mousemove', onMouseMove);
+  document.addEventListener('mouseup', onMouseUp);
+  e.preventDefault(); // Prevent text selection during drag
+}
+
+function onMouseMove(e: MouseEvent) {
+  if (!isDragging.value || !container.value) return;
+  
+  const containerRect = container.value.getBoundingClientRect();
+  const containerWidth = containerRect.width;
+  const mouseX = e.clientX - containerRect.left;
+  
+  // Calculate percentage position
+  let newSplitPercentage = (mouseX / containerWidth) * 100;
+  
+  // Apply min constraints
+  newSplitPercentage = Math.max(props.minLeft, Math.min(100 - props.minRight, newSplitPercentage));
+  
+  splitPercentage.value = newSplitPercentage;
+  updateSplit();
+}
+
+function onMouseUp() {
+  isDragging.value = false;
+  document.removeEventListener('mousemove', onMouseMove);
+  document.removeEventListener('mouseup', onMouseUp);
+}
+</script>
+
+<template>
+  <div 
+    ref="container" 
+    class="split-pane-container flex flex-row h-full w-full"
+  >
+    <div 
+      ref="leftPane" 
+      class="split-pane-left overflow-hidden"
+    >
+      <slot name="left"></slot>
+    </div>
+    
+    <div 
+      ref="splitter" 
+      class="split-pane-divider w-1 bg-gray-300 hover:bg-gray-500 cursor-col-resize transition-colors"
+      @mousedown="onMouseDown"
+    ></div>
+    
+    <div 
+      ref="rightPane" 
+      class="split-pane-right overflow-hidden"
+    >
+      <slot name="right"></slot>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.split-pane-container {
+  position: relative;
+}
+
+.split-pane-divider {
+  cursor: col-resize;
+  user-select: none;
+  z-index: 10;
+}
+
+.split-pane-left, .split-pane-right {
+  overflow: hidden;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,95 +1,25 @@
+<script setup lang="ts">
+// Default initial split percentage (50% for code editor, 50% for game screen)
+const initialSplit = 50;
+</script>
+
 <template>
   <div class="flex flex-col h-screen w-screen">
     <GlobalHeader />
     <div class="flex flex-grow p-1 h-[90%]">
-      <div
-        ref="resizeEditorElement"
-        class="flex min-w-[300px] h-full w-1/2 mr-2"
+      <SplitPane
+        :initial-split="initialSplit"
+        :min-left="20"
+        :min-right="20"
+        storage-key="code-game-split-position"
       >
-        <CodeEditor />
-      </div>
-      <div
-        ref="separator"
-        class="w-1 bg-gray-300 cursor-ew-resize"
-      />
-      <div
-        ref="resizeGameElement"
-        class="flex min-w-[300px] w-1/2 overflow-auto"
-      >
-        <GameScreen />
-      </div>
+        <template #left>
+          <CodeEditor />
+        </template>
+        <template #right>
+          <GameScreen />
+        </template>
+      </SplitPane>
     </div>
   </div>
 </template>
-
-<script lang="ts">
-import { defineComponent, ref, onMounted, onUnmounted } from "vue";
-
-export default defineComponent({
-  setup() {
-    const isResizing = ref(false);
-    const initialX = ref(0);
-    const initialWidthEditor = ref(0);
-    const initialWidthGame = ref(0);
-    const resizeEditorElement = ref<HTMLDivElement | null>(null);
-    const resizeGameElement = ref<HTMLDivElement | null>(null);
-    const separator = ref<HTMLDivElement | null>(null);
-
-    const startResize = (e: MouseEvent) => {
-      if (!resizeEditorElement.value) {
-        throw new Error("unexpected: no resizeEditorElement");
-      }
-      if (!resizeGameElement.value) {
-        throw new Error("unexpected: no resizeGameElement");
-      }
-      isResizing.value = true;
-      initialX.value = e.clientX;
-      initialWidthEditor.value = resizeEditorElement.value.offsetWidth;
-      initialWidthGame.value = resizeGameElement.value.offsetWidth;
-    };
-
-    const handleResize = (e: MouseEvent) => {
-      if (!resizeEditorElement.value) {
-        throw new Error("unexpected: no resizeEditorElement");
-      }
-      if (!resizeGameElement.value) {
-        throw new Error("unexpected: no resizeGameElement");
-      }
-      if (isResizing.value) {
-        const dx = e.clientX - initialX.value;
-        const newWidthEditor = initialWidthEditor.value + dx;
-        const newWidthGame = initialWidthGame.value - dx;
-        resizeEditorElement.value.style.width = `${newWidthEditor}px`;
-        resizeGameElement.value.style.width = `${newWidthGame}px`;
-      }
-    };
-
-    const stopResize = () => {
-      isResizing.value = false;
-    };
-
-    onMounted(() => {
-      if (!separator.value) {
-        throw new Error("unexpected: no separator");
-      }
-      separator.value.addEventListener("mousedown", startResize);
-      document.addEventListener("mousemove", handleResize);
-      document.addEventListener("mouseup", stopResize);
-    });
-
-    onUnmounted(() => {
-      if (!separator.value) {
-        throw new Error("unexpected: no separator");
-      }
-      separator.value.removeEventListener("mousedown", startResize);
-      document.removeEventListener("mousemove", handleResize);
-      document.removeEventListener("mouseup", stopResize);
-    });
-    return {
-      resizeEditorElement,
-      resizeGameElement,
-      separator,
-    };
-  },
-});
-</script>


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model anthropic/claude-3-7-sonnet-20250219 --yes-always
```

Prompt:
> Please, solve the following issue. Title: feat: draggable splitter between the code and the game screen should remember its position between the page reloads. Description: Let's persist it in the localStorage.

Cost: $0.12 USD.

## Limitations

<!-- Anything related to this PR that wasn't "done" in this PR -->

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
