### PR TITLE
[Aider 0.75.2] [anthropic/claude-3-7-sonnet-20250219] [$0.06] [🔴 doesn't work] feat: Add inactive flag to users and filter out inactive bots

### DIFF
--- a/schema.prisma
+++ b/schema.prisma
@@ -11,6 +11,7 @@ model User {
   id        Int         @id @default(autoincrement())
   password  String
   username  String      @unique
+  inactive  Boolean     @default(false)
   game_stats GameStats[]
 }
 

--- a/server/api/bot/submit.post.ts
+++ b/server/api/bot/submit.post.ts
@@ -28,7 +28,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  botCodeStore.submitBotCode({
+  await botCodeStore.submitBotCode({
     username: event.context.user.username,
     userId: event.context.user.id,
     code: result.data.code,

--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -28,14 +28,17 @@ type RunBotArgs = {
 };
 
 async function runBots({ bots, world, prevBotState, botApi }: RunBotArgs) {
-  for (const bot of Object.values(bots)) {
+  // Only process bots that are not marked as inactive
+  const activeBots = Object.values(bots).filter(bot => !bot.inactive);
+  
+  for (const bot of activeBots) {
     if (!world.hasBot(bot.id)) {
       world.addBot(bot.id);
     }
   }
 
   const state = world.getState();
-  const botArray = Object.values(bots);
+  const botArray = Object.values(bots).filter(bot => !bot.inactive);
 
   const preparedBotCodes = botArray.map(bot => prepareBotCode({
     bot,


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model anthropic/claude-3-7-sonnet-20250219 --yes-always
```

Prompt:
> Please, solve the following issue. Title: feat: allow turning off the bots of some users by setting the "inactive" field in the database on the user object to true. Description: add inactive boolean field to the database
> add logic that ignores that user bot if inactive=true (never load it, never process it)
> if that user submits the bot code, set inactive=false

Cost: $0.06 USD.

## Notes

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/70128e56-66fb-4972-8465-965a4a10d453" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
