### PR TITLE
[Aider] [Claude 3.7] [$0.07] feat: Enhance game screen responsiveness and scaling to occupy full available space

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,7 @@
       />
       <div
         ref="resizeGameElement"
-        class="flex min-w-[300px] w-1/2 overflow-auto"
+        class="flex min-w-[300px] h-full w-1/2"
       >
         <GameScreen />
       </div>
@@ -34,6 +34,23 @@ export default defineComponent({
     const resizeEditorElement = ref<HTMLDivElement | null>(null);
     const resizeGameElement = ref<HTMLDivElement | null>(null);
     const separator = ref<HTMLDivElement | null>(null);
+    
+    // Function to handle window resize events
+    const handleWindowResize = () => {
+      if (appRef.value && canvas.value && gameState.value) {
+        const containerWidth = canvas.value.parentElement?.clientWidth || gameState.value.width;
+        const containerHeight = canvas.value.parentElement?.clientHeight || gameState.value.height;
+        
+        const scaleX = containerWidth / gameState.value.width;
+        const scaleY = containerHeight / gameState.value.height;
+        const scale = Math.min(scaleX, scaleY);
+        
+        const scaledWidth = Math.floor(gameState.value.width * scale);
+        const scaledHeight = Math.floor(gameState.value.height * scale);
+        
+        appRef.value.renderer.resize(scaledWidth, scaledHeight);
+      }
+    };
 
     const startResize = (e: MouseEvent) => {
       if (!resizeEditorElement.value) {
@@ -75,6 +92,9 @@ export default defineComponent({
       separator.value.addEventListener("mousedown", startResize);
       document.addEventListener("mousemove", handleResize);
       document.addEventListener("mouseup", stopResize);
+      
+      // Add window resize event listener
+      window.addEventListener("resize", handleWindowResize);
     });
 
     onUnmounted(() => {
@@ -84,6 +104,9 @@ export default defineComponent({
       separator.value.removeEventListener("mousedown", startResize);
       document.removeEventListener("mousemove", handleResize);
       document.removeEventListener("mouseup", stopResize);
+      
+      // Remove window resize event listener
+      window.removeEventListener("resize", handleWindowResize);
     });
     return {
       resizeEditorElement,


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model anthropic/claude-3-7-sonnet-20250219 --yes-always
```

Prompt:
> Please, solve the following issue. Title: feat: ensure that the game screen occupies all available free space to the right of the code editor. The game screen should scale and occupy the available free space to the right of the code editor.

Cost: $0.07 USD.

## Limitations

<!-- Anything related to this PR that wasn't "done" in this PR -->

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
