### PR TITLE
[Aider] [Claude 3.7] [$0.10] feat: add code versioning with ability to view and restore previous versions

### DIFF
--- a/components/CodeVersionHistory.vue
+++ b/components/CodeVersionHistory.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { CodeVersion } from "~/other/botCodeStore";
+
+const props = defineProps<{
+  versions: CodeVersion[];
+  onClose: () => void;
+  onRestore: (code: string) => void;
+}>();
+
+const selectedVersionIndex = ref(0);
+
+const formattedVersions = computed(() => {
+  return props.versions.map((version, index) => {
+    const date = new Date(version.timestamp);
+    return {
+      ...version,
+      formattedDate: date.toLocaleString(),
+      isSelected: index === selectedVersionIndex.value
+    };
+  });
+});
+
+function selectVersion(index: number) {
+  selectedVersionIndex.value = index;
+}
+
+function restoreSelectedVersion() {
+  if (props.versions.length > 0) {
+    props.onRestore(props.versions[selectedVersionIndex.value].code);
+    props.onClose();
+  }
+}
+</script>
+
+<template>
+  <div class="flex h-full">
+    <!-- Left side: Code preview -->
+    <div class="w-2/3 h-full pr-4">
+      <MonacoEditor
+        v-if="versions.length > 0"
+        v-model="versions[selectedVersionIndex].code"
+        lang="javascript"
+        :options="{
+          readOnly: true,
+          readOnlyMessage: { value: 'Cannot edit version preview' },
+          smoothScrolling: true,
+          scrollBeyondLastLine: false,
+          minimap: { enabled: false },
+        }"
+        class="h-full"
+      />
+      <div v-else class="flex items-center justify-center h-full bg-gray-100">
+        <p class="text-gray-500">No previous versions found</p>
+      </div>
+    </div>
+    
+    <!-- Right side: Version list -->
+    <div class="w-1/3 h-full overflow-y-auto border-l pl-4">
+      <h3 class="text-lg font-semibold mb-4">Version History</h3>
+      
+      <div v-if="versions.length === 0" class="text-gray-500">
+        No previous versions available
+      </div>
+      
+      <ul v-else class="space-y-2">
+        <li 
+          v-for="(version, index) in formattedVersions" 
+          :key="version.timestamp"
+          @click="selectVersion(index)"
+          :class="[
+            'p-2 cursor-pointer rounded transition-colors',
+            version.isSelected ? 'bg-blue-100' : 'hover:bg-gray-100'
+          ]"
+        >
+          <div class="font-medium">{{ version.formattedDate }}</div>
+        </li>
+      </ul>
+      
+      <div class="mt-6 flex justify-end">
+        <button
+          v-if="versions.length > 0"
+          @click="restoreSelectedVersion"
+          class="h-10 px-6 font-semibold shadow bg-black text-white hover:bg-gray-800 transition"
+        >
+          Restore This Version
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/other/botCodeStore.ts
+++ b/other/botCodeStore.ts
@@ -1,5 +1,6 @@
 import EventEmitter from "node:events";
 import fs from "node:fs";
+import path from "node:path";
 
 const BOT_CODE_DIR = process.env.BOT_CODE_DIR || "./bot-code";
 
@@ -8,6 +9,12 @@ export interface BotCode {
   code: string;
   username: string;
   userId: number;
+}
+
+export interface CodeVersion {
+  code: string;
+  timestamp: number;
+  id: string;
 }
 
 export type BotCodes = Record<string, BotCode>;
@@ -27,7 +34,11 @@ export function submitBotCode({ code, username, userId }: SubmitBotCodeArgs) {
   const id = Object.values(STORE).find(botCode => botCode.username === username)?.id || Math.random().toString(36).substring(5);
   const botCode = { id, code, username, userId };
   STORE[id] = botCode;
+  
+  // Save both the latest version and a timestamped version
   saveBot(botCode);
+  saveBotVersion(botCode);
+  
   botEventEmitter.emit("update", STORE);
 }
 
@@ -44,14 +55,50 @@ export function subscribeToBotsUpdate(onUpdate: (bots: BotCodes) => void): () =>
   return () => botEventEmitter.off("update", onUpdate);
 }
 
+export function getUserCodeVersions(userId: number): CodeVersion[] {
+  if (!fs.existsSync(BOT_CODE_DIR)) {
+    return [];
+  }
+
+  const files = fs.readdirSync(BOT_CODE_DIR);
+  const versionFiles = files.filter(file => {
+    const parts = file.split("-");
+    return parts.length >= 4 && parts[2] === userId.toString() && parts[3].includes("version");
+  });
+
+  return versionFiles.map(file => {
+    const code = fs.readFileSync(path.join(BOT_CODE_DIR, file), "utf8");
+    const parts = file.split("-");
+    const timestamp = parseInt(parts[3].replace("version", "").replace(".js", ""));
+    const id = parts[1];
+    
+    return {
+      code,
+      timestamp,
+      id
+    };
+  }).sort((a, b) => b.timestamp - a.timestamp); // Sort newest first
+}
+
+export function getLatestUserCode(userId: number): string | null {
+  const userBot = Object.values(STORE).find(bot => bot.userId === userId);
+  if (userBot) {
+    return userBot.code;
+  }
+  return null;
+}
+
 function loadBots() {
   if (!fs.existsSync(BOT_CODE_DIR)) {
     return;
   }
 
   const files = fs.readdirSync(BOT_CODE_DIR);
+  
+  // Only load the latest versions (non-versioned files)
+  const latestFiles = files.filter(file => !file.includes("version"));
 
-  for (const file of files) {
+  for (const file of latestFiles) {
     const code = fs.readFileSync(`${BOT_CODE_DIR}/${file}`, "utf8");
     const username = file.split("-")[0];
     const id = file.split("-")[1];
@@ -70,6 +117,17 @@ function saveBot({ id, code, username, userId }: BotCode) {
   const botCodeFile = `${BOT_CODE_DIR}/${username}-${id}-${userId}.js`;
 
   fs.writeFileSync(botCodeFile, code);
+}
+
+function saveBotVersion({ id, code, username, userId }: BotCode) {
+  if (!fs.existsSync(BOT_CODE_DIR)) {
+    fs.mkdirSync(BOT_CODE_DIR);
+  }
+  
+  const timestamp = Date.now();
+  const versionFile = `${BOT_CODE_DIR}/${username}-${id}-${userId}-version${timestamp}.js`;
+  
+  fs.writeFileSync(versionFile, code);
 }
 
 loadBots();

--- a/server/api/bot/versions.get.ts
+++ b/server/api/bot/versions.get.ts
@@ -1,0 +1,27 @@
+import { getUserCodeVersions } from "~/other/botCodeStore";
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event);
+  const userId = parseInt(query.userId as string);
+  
+  if (isNaN(userId)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid user ID",
+    });
+  }
+
+  // Check if the requesting user is the same as the user whose versions are being requested
+  if (event.context.user.id !== userId) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: "Unauthorized to access other users' code versions",
+    });
+  }
+
+  const versions = getUserCodeVersions(userId);
+  
+  return {
+    versions,
+  };
+});


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model anthropic/claude-3-7-sonnet-20250219 --yes-always
```

Prompt:
> Please, solve the following issue. Title: feat: add code versions and an option to revert to a previous version. Description: **Goal:** let the user revert to the previous code version
> Proposed implementation:
> - every time the user submits code, store it separately, don't overwrite the previous code version
>     - we can use filenames with dates in them, for example: `<userid>-<timestamp>.js`
>     - use a special name, like `<userid>-latest.js` for the latest code version so we can quickly retrieve it by path
> - add a modal that will allow the user to view previous submissions in the UI and revert to them
>     - the button to open a modal should be above the code editor
>     - the modal left side should be occupied by the read-only code editor
>     - the modal on the right side should be occupied by the list of versions
>     - user can click any of the versions to preview them in the modal
>     - user can click the restore button to restore the version
>     - restoring the code doesn't create a new version until the user submits the code again
> Let me know if you want to work on this ticket and if you have any questions!

Cost: $0.10 USD.

## Limitations

<!-- Anything related to this PR that wasn't "done" in this PR -->

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
