### PR TITLE
[Aider 0.75.2] [anthropic/claude-3-7-sonnet-20250219] [$0.05] [🔴 doesn't work] feat: surface bot execution errors to the user

### DIFF
--- a/server/api/state.get.ts
+++ b/server/api/state.get.ts
@@ -1,12 +1,19 @@
-import { WORLD_REF } from "../plugins/engine";
+import { WORLD_REF, BOT_ERRORS } from "../plugins/engine";
 import * as botCodeStore from "~/other/botCodeStore";
 
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
   const gameState = WORLD_REF.world.getState();
-
   const botCodes = botCodeStore.getBots();
+  
+  // Get the current user ID from the session
+  const session = await useSession(event);
+  const userId = session.data.user?.id;
+  
+  // Get error for the current user if it exists
+  const errorStack = userId ? BOT_ERRORS[userId] : undefined;
 
   return {
+    errorStack,
     ...gameState,
     bots: Object.fromEntries([...gameState.bots.entries()].map(([id, bot]) => {
       const botCode = botCodes[bot.botId];

--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -6,6 +6,9 @@ import World, { type WorldState } from "~/other/world";
 import { recordGameEnd, type GameStat } from "~/other/recordGamedb";
 import { CodeRunner } from "~/other/CodeRunner";
 
+// Store bot execution errors by userId
+export const BOT_ERRORS: Record<number, string> = {};
+
 const MAX_ROUND_TIME_MS = 15 * 1000 * 60;
 const GAME_STEP_INTERVAL_MS = 250;
 const WORLD_SIZE = 600;
@@ -62,7 +65,10 @@ async function runBots({ bots, world, prevBotState, botApi }: RunBotArgs) {
       const result = await codeRunner.runCode(preparedCode);
       return JSON.parse(result);
     } catch (err) {
-      // TODO(yurij): notify user that their bot crashed
+      // Store the error for this bot
+      if (bot.userId && err instanceof Error) {
+        BOT_ERRORS[bot.userId] = err.stack || err.message;
+      }
       console.error(err);
       return [];
     } finally {


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model anthropic/claude-3-7-sonnet-20250219 --yes-always
```

Prompt:
> Please, solve the following issue. Title: feat: surface bot execution errors to the user. Description: **Goal:** If the bot crashed, we should display this to the user and show the error that caused the crash.
> It crashes here: aibyss/server/plugins/engine.ts
> Lines 52 to 53 in c0af374
> 
> |     |                                                    |
> | --- | -------------------------------------------------- |
> |     | // TODO(yurij): notify user that their bot crashed |
> |     | console.log(err);                                  |
> 
> This error:
> - needs to be captured and attached to the `state` returned by `state.get.ts`
>     - let’s add a new `errorStack` field at the top level of the object returned by `state.get.ts`. This field can either be absent if there’s no error, or contain a string with the error’s stack trace.
> - if it’s not `undefined`, display it below the code editing field and above the submit button. The code editing field can be slightly reduced in size if an error occurs.
> **Important considerations:**
> - Only return the error related to the player’s bot; do not return errors for all bots that have crashed.
>     - This isn’t useful for the interface and will bloat the `state` object.
> - In the interface, the error should be displayed in such a way that:
>     - Even if it’s very long, it should not cover the entire code editor – it should have a maximum height and be scrollable.
>     - The frontend updates state every second – if the same error keeps appearing, it should not flicker in the interface.
>     - Sometimes errors occur intermittently; for example, there might be several logical branches in the bot’s code and only one branch causes a crash.
>         - We need to ensure the interface does not flicker if the error disappears and reappears.
>         - To solve this, we’ll hide the error from the interface only after the user manually dismisses it (we need to add a close button to the error window). This way, even if the crash happens once a minute, the user a) will see it and b) will have time to study the error calmly and fix it.
> **What we are not doing in this PR:**
> - Streaming errors via websockets – not needed right now, since we continuously update the game state, and the user will still get the latest error. Let’s just use the existing `/state` API to return it.
>     - **Why:** Simplicity and time-saving. From the user’s perspective, the result is the same. If we encounter issues with this, we’ll address them in a separate PR – not in this one.
> - Returning an array of errors or all errors that occurred – we will return only the current error if it exists. The interface can then decide what to do with it and how to display it.
>     - **Why:** Simplicity. No need to consider error history, etc. It won’t significantly affect the user experience for this PR. In 99% of cases, the bot will crash repeatedly in the same way, returning the same single error.
> - Persisting errors
>     - It’s enough to store them in the application’s memory since these are ephemeral data – they have no special value after a restart. If the bot crashes, it will crash again after a restart, and the user will see the error.
> **The focus of this PR is to:**
> - Capture the current error, if any, and include it in `state` in the simplest and quickest way.
> - Display it neatly in the interface – so that the error helps the user rather than getting in their way.

Cost: $0.05 USD.

## Notes

The solution doesn't work. Also, it didn't try editing the UI to surface the bot execution errors to the user.

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/d215b73d-dc54-4218-95d7-c9e3745fdc45" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
