### PR TITLE
[Aider 0.75.2] [DeepSeek-v3] [$0.0046] [🔴 doesn't work] feat: persist draggable splitter position in localStorage

### DIFF
--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -401,8 +401,9 @@ watch(gameState, async (newState, prevState) => {
 
 <template>
   <div
-    class="h-full w-full"
+    class="h-full"
     data-testid="game-screen"
+    :style="{ width: `calc(100% - ${splitterPosition}% - ${SPLITTER_WIDTH}px)` }"
   >
     <div
       ref="gameScreen"
@@ -421,3 +422,14 @@ watch(gameState, async (newState, prevState) => {
     </div>
   </div>
 </template>
+.splitter {
+  transition: background-color 0.2s;
+}
+
+.splitter:active {
+  background-color: #9CA3AF;
+}
+
+.editor-container {
+  min-width: 600px;
+}


### PR DESCRIPTION
## How does this PR impact the user?

Related to #116.

## Description

This PR was created by `aider` ran with:

```sh
aider --model deepseek/deepseek-chat --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat: draggable splitter between the code and the game screen should remember its position between the page reloads. Description: Let's persist it in the localStorage.

Cost: $0.0046 USD.

## Notes

- Identified the wrong files to edit
- Has broken the code editor

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/477c17d0-8d4a-4908-8998-064ca4278796" />

## Checklist

- [x] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
