### PR TITLE
[Aider 0.75.2] [DeepSeek-v3] [$0.0043] [🔴 doesn't work] feat: add inactive user flag to disable bot processing

### DIFF
--- a/schema.prisma
+++ b/schema.prisma
@@ -11,6 +11,7 @@ model User {
   id        Int         @id @default(autoincrement())
   password  String
   username  String      @unique
+  inactive  Boolean     @default(false)
   game_stats GameStats[]
 }
 

--- a/server/api/bot/submit.post.ts
+++ b/server/api/bot/submit.post.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import * as botCodeStore from "~/other/botCodeStore";
 import { HTTP_STATUS_CODES } from "~/other/httpStatusCodes";
 import { SUBMIT_COOLDOWN_MS } from "~/other/submitApiRatelimitConstants";
+import { db } from "~/other/db";
 
 const submitBotCodeSchema = z.object({
   code: z.string(),
@@ -27,6 +28,12 @@ export default defineEventHandler(async (event) => {
       statusMessage: "Username and password field is required",
     });
   }
+
+  // Activate user if they were inactive
+  await db.user.update({
+    where: { id: event.context.user.id },
+    data: { inactive: false }
+  });
 
   botCodeStore.submitBotCode({
     username: event.context.user.username,

--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -29,7 +29,13 @@ type RunBotArgs = {
 
 async function runBots({ bots, world, prevBotState, botApi }: RunBotArgs) {
   for (const bot of Object.values(bots)) {
-    if (!world.hasBot(bot.id)) {
+    // Skip inactive users' bots
+    const user = await db.user.findUnique({
+      where: { id: bot.userId },
+      select: { inactive: true }
+    });
+
+    if (!user?.inactive && !world.hasBot(bot.id)) {
       world.addBot(bot.id);
     }
   }


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model deepseek/deepseek-chat --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat: allow turning off the bots of some users by setting the "inactive" field in the database on the user object to true. Description: add inactive boolean field to the database
> add logic that ignores that user bot if inactive=true (never load it, never process it)
> if that user submits the bot code, set inactive=false

Cost: $0.0043 USD.

## Notes

It messed up the db import.

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
