### PR TITLE
[Aider] [DeepSeek-v3] [$0.0042] feat: make game screen responsive to occupy available space next to code editor

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2,6 +2,19 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Custom styles for game layout */
+.game-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.game-screen {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
 @layer base {
   @font-face {
     font-family: 'Retropix';

--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -61,7 +61,7 @@ function onCloseAPIReferenceModal() {
 
 <template>
   <div
-    class="w-full h-full font-sans flex flex-col"
+    class="w-full h-full font-sans flex flex-col min-w-[600px]"
     data-testid="code-editor"
   >
     <form

--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -401,13 +401,17 @@ watch(gameState, async (newState, prevState) => {
 
 <template>
   <div
-    class="h-full w-full"
+    class="h-full w-full flex-grow overflow-hidden"
     data-testid="game-screen"
   >
     <div
       ref="gameScreen"
-      class="flex flex-col shadow ml-2"
-      :style="{ maxWidth: gameState?.width + 'px' }"
+      class="flex flex-col shadow ml-2 h-full"
+      :style="{ 
+        maxWidth: gameState?.width + 'px',
+        width: '100%',
+        height: '100%'
+      }"
     >
       <div class="flex flex-row justify-end mb-2 mt-1 mx-4 gap-6">
         <ButtonLink
@@ -417,7 +421,7 @@ watch(gameState, async (newState, prevState) => {
           {{ isFollowing ? "stop following my bot" : "follow my bot" }}
         </ButtonLink>
       </div>
-      <canvas ref="canvas" />
+      <canvas ref="canvas" class="flex-grow" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model deepseek/deepseek-chat --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat: ensure that the game screen occupies all available free space to the right of the code editor. Description: The game screen should scale and occupy the available free space to the right of the code editor.

Cost: $0.0042 USD.

## Limitations

<!-- Anything related to this PR that wasn't "done" in this PR -->

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
