### PR TITLE
[Aider] [DeepSeek-v3] [$0.0082] feat: display bot execution errors in CodeEditor component

### DIFF
--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -33,7 +33,22 @@ const state = reactive({
   code: user.value?.body.code || defaultCode,
   codeHasErrors: false,
   showAPIReference: false,
+  botError: null as string | null,
+  isErrorVisible: false,
 });
+
+const { data: gameState } = await useFetch("/api/state");
+
+watch(gameState, (newState) => {
+  if (newState?.errorStack) {
+    state.botError = newState.errorStack;
+    state.isErrorVisible = true;
+  }
+});
+
+function dismissError() {
+  state.isErrorVisible = false;
+}
 
 function onSubmit(event: Event) {
   event.preventDefault();
@@ -86,7 +101,26 @@ function onCloseAPIReferenceModal() {
           }"
         />
       </div>
-      <div class="flex justify-end">
+      <div class="flex flex-col gap-4">
+        <div
+          v-if="state.isErrorVisible && state.botError"
+          class="relative bg-red-50 border border-red-200 rounded p-4"
+        >
+          <button
+            @click="dismissError"
+            class="absolute top-2 right-2 text-red-500 hover:text-red-700"
+            aria-label="Dismiss error"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+            </svg>
+          </button>
+          <div class="text-red-600 font-mono text-sm overflow-auto max-h-40">
+            {{ state.botError }}
+          </div>
+        </div>
+        
+        <div class="flex justify-end">
         <button
           type="submit"
           class="h-10 px-6 font-semibold shadow bg-black text-white hover:bg-gray-800 transition disabled:opacity-50 disabled:bg-black disabled:cursor-not-allowed"


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model deepseek/deepseek-chat --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat: surface bot execution errors to the user. Description: **Goal:** If the bot crashed, we should display this to the user and show the error that caused the crash.
> It crashes here: aibyss/server/plugins/engine.ts
> Lines 52 to 53 in c0af374
> 
> |     |                                                    |
> | --- | -------------------------------------------------- |
> |     | // TODO(yurij): notify user that their bot crashed |
> |     | console.log(err);                                  |
> 
> This error:
> - needs to be captured and attached to the `state` returned by `state.get.ts`
>     - let’s add a new `errorStack` field at the top level of the object returned by `state.get.ts`. This field can either be absent if there’s no error, or contain a string with the error’s stack trace.
> - if it’s not `undefined`, display it below the code editing field and above the submit button. The code editing field can be slightly reduced in size if an error occurs.
> **Important considerations:**
> - Only return the error related to the player’s bot; do not return errors for all bots that have crashed.
>     - This isn’t useful for the interface and will bloat the `state` object.
> - In the interface, the error should be displayed in such a way that:
>     - Even if it’s very long, it should not cover the entire code editor – it should have a maximum height and be scrollable.
>     - The frontend updates state every second – if the same error keeps appearing, it should not flicker in the interface.
>     - Sometimes errors occur intermittently; for example, there might be several logical branches in the bot’s code and only one branch causes a crash.
>         - We need to ensure the interface does not flicker if the error disappears and reappears.
>         - To solve this, we’ll hide the error from the interface only after the user manually dismisses it (we need to add a close button to the error window). This way, even if the crash happens once a minute, the user a) will see it and b) will have time to study the error calmly and fix it.
> **What we are not doing in this PR:**
> - Streaming errors via websockets – not needed right now, since we continuously update the game state, and the user will still get the latest error. Let’s just use the existing `/state` API to return it.
>     - **Why:** Simplicity and time-saving. From the user’s perspective, the result is the same. If we encounter issues with this, we’ll address them in a separate PR – not in this one.
> - Returning an array of errors or all errors that occurred – we will return only the current error if it exists. The interface can then decide what to do with it and how to display it.
>     - **Why:** Simplicity. No need to consider error history, etc. It won’t significantly affect the user experience for this PR. In 99% of cases, the bot will crash repeatedly in the same way, returning the same single error.
> - Persisting errors
>     - It’s enough to store them in the application’s memory since these are ephemeral data – they have no special value after a restart. If the bot crashes, it will crash again after a restart, and the user will see the error.
> **The focus of this PR is to:**
> - Capture the current error, if any, and include it in `state` in the simplest and quickest way.
> - Display it neatly in the interface – so that the error helps the user rather than getting in their way.

Cost: $0.0082 USD.

## Limitations

<!-- Anything related to this PR that wasn't "done" in this PR -->

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
