### PR TITLE
[Aider] [o3-mini-high] [$0.01] feat: Persist draggable splitter position in localStorage between reloads

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -66,11 +66,24 @@ export default defineComponent({
 
     const stopResize = () => {
       isResizing.value = false;
+      if (resizeEditorElement.value && resizeGameElement.value) {
+        localStorage.setItem("editorWidth", resizeEditorElement.value.style.width);
+        localStorage.setItem("gameWidth", resizeGameElement.value.style.width);
+      }
     };
 
     onMounted(() => {
       if (!separator.value) {
         throw new Error("unexpected: no separator");
+      }
+      // Load persisted widths from localStorage
+      const storedEditorWidth = localStorage.getItem("editorWidth");
+      const storedGameWidth = localStorage.getItem("gameWidth");
+      if (storedEditorWidth && resizeEditorElement.value) {
+        resizeEditorElement.value.style.width = storedEditorWidth;
+      }
+      if (storedGameWidth && resizeGameElement.value) {
+        resizeGameElement.value.style.width = storedGameWidth;
       }
       separator.value.addEventListener("mousedown", startResize);
       document.addEventListener("mousemove", handleResize);


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model o3-mini --reasoning-effort high --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat: draggable splitter between the code and the game screen should remember its position between the page reloads. Description: Let's persist it in the localStorage.

Cost: $0.01 USD.

## Limitations

- it required me to manually add a file

<img width="959" alt="Screenshot 2025-03-16 at 17 43 38" src="https://github.com/user-attachments/assets/478d2527-327b-4c82-84e0-9263abb95471" />
<img width="957" alt="Screenshot 2025-03-16 at 17 44 59" src="https://github.com/user-attachments/assets/f11eef47-ba05-4412-a327-af7bf05335f2" />
<img width="957" alt="Screenshot 2025-03-16 at 17 47 13" src="https://github.com/user-attachments/assets/ad39204b-91b3-4414-95e5-a3d4ba58fbff" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
