### PR TITLE
[Aider] [o3-mini-high] [$0.02] feat: Scale game screen to occupy all available space beside code editor

### DIFF
--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -406,8 +406,7 @@ watch(gameState, async (newState, prevState) => {
   >
     <div
       ref="gameScreen"
-      class="flex flex-col shadow ml-2"
-      :style="{ maxWidth: gameState?.width + 'px' }"
+      class="flex flex-col shadow ml-2 w-full"
     >
       <div class="flex flex-row justify-end mb-2 mt-1 mx-4 gap-6">
         <ButtonLink

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,7 @@
       />
       <div
         ref="resizeGameElement"
-        class="flex min-w-[300px] w-1/2 overflow-auto"
+        class="flex min-w-[300px] flex-1 overflow-auto"
       >
         <GameScreen />
       </div>


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model o3-mini --reasoning-effort high --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat: ensure that the game screen occupies all available free space to the right of the code editor. The game screen should scale and occupy the available free space to the right of the code editor.

Cost: $0.02 USD.

## Limitations

- it required the user to manually add the files once

<img width="955" alt="Screenshot 2025-03-16 at 18 06 47" src="https://github.com/user-attachments/assets/26bb783f-2b1b-4e4b-8b65-645dca6da3ec" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
