### PR TITLE
[Aider] [o3-mini-high] [$0.03] feat: add code submission counter to rating table and user stats

### DIFF
--- a/New file: migrations/20250316120000_add_submission_count_to_user/migration.sql
+++ b/New file: migrations/20250316120000_add_submission_count_to_user/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "submissionCount" INT NOT NULL DEFAULT 0;

--- a/components/RatingTable.vue
+++ b/components/RatingTable.vue
@@ -34,6 +34,12 @@ const isModalOpen = ref(false);
                 scope="col"
                 class="px-6 py-3"
               >
+                submissions
+              </th>
+              <th
+                scope="col"
+                class="px-6 py-3"
+              >
                 score
               </th>
               <th
@@ -121,6 +127,9 @@ const isModalOpen = ref(false);
               >
                 {{ userRating.username }}
               </th>
+              <td class="px-6 py-4">
+                {{ userRating.submissionCount }}
+              </td>
               <td class="px-6 py-4">
                 {{ userRating.score7days }}
               </td>

--- a/server/api/rating.get.ts
+++ b/server/api/rating.get.ts
@@ -9,6 +9,7 @@ type UserStats = {
   foodEaten: number;
   maxEndgameSize: number;
   avgEndgameSize: number;
+  submissionCount: number;
 };
 
 export type UserRating = UserStats & {
@@ -75,6 +76,7 @@ export default defineEventHandler(async () => {
       const rawUserStat = rawUserStats[stat.user_id] || (rawUserStats[stat.user_id] = {
         userId: stat.user_id,
         username: user.username,
+        submissionCount: user.submissionCount,
         stats7days: getEmptyRawStats(),
         stats24hours: getEmptyRawStats(),
         stats1hour: getEmptyRawStats(),
@@ -152,6 +154,7 @@ export default defineEventHandler(async () => {
       ...rawUserStat.stats7days,
       userId: rawUserStat.userId,
       username: rawUserStat.username,
+      submissionCount: rawUserStat.submissionCount,
       maxEndgameSize: Math.max(...rawUserStat.stats7days.endgameSizes),
       avgEndgameSize: (
         rawUserStat.stats7days.endgameSizes.reduce((acc, size) => acc + size, 0)


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model o3-mini --reasoning-effort high --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat(rating): add a new column to the rating table displaying the number of times the user submitted the code. Description: add a way for us to track how many times the user submitted the code
> return the number to the client with the game stats
> display it in the rating table

Cost: $0.03 USD.

## Limitations

- I had to manually add source code files to the session

<img width="747" alt="Screenshot 2025-03-16 at 21 02 50" src="https://github.com/user-attachments/assets/d6fcaae9-a840-4c0f-a735-f8b16e78f0bd" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
