### PR TITLE
[Aider] [o3-mini-high] [$0.01] fix: Set default button type to prevent form submission on API reference click

### DIFF
--- a/components/ButtonLink.vue
+++ b/components/ButtonLink.vue
@@ -1,5 +1,14 @@
+<script setup lang="ts">
+const props = defineProps({
+  type: {
+    type: String,
+    default: 'button'
+  }
+});
+</script>
+
 <template>
-  <button class="text-indigo-600 hover:text-indigo-400">
+  <button :type="type" class="text-indigo-600 hover:text-indigo-400" v-bind="$attrs">
     <slot />
   </button>
 </template>


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model o3-mini --reasoning-effort high --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: bug: fix the issue causing the bot code to submit when the user opens "API reference". Description: Every time the user clicks on the "API reference" link, we submit the bot code. Let's figure out why this happens and fix the issue.

Cost: $0.01 USD.

## Limitations

<!-- Anything related to this PR that wasn't "done" in this PR -->

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
