### PR TITLE
[Claude Code 0.2.35] [claude-3-7-sonnet-20250219] [$0.1175] [🔴 doesn't work] feat: highlight top results in rating table with bold styling

### DIFF
--- a/components/RatingTable.vue
+++ b/components/RatingTable.vue
@@ -2,6 +2,27 @@
 const { data: rating, status } = await useFetch("/api/rating");
 
 const isModalOpen = ref(false);
+
+// Find max values for each column to highlight
+const maxKills = computed(() => {
+  if (!rating?.length) return 0;
+  return Math.max(...rating.map(user => user.kills || 0));
+});
+
+const maxDeaths = computed(() => {
+  if (!rating?.length) return 0;
+  return Math.max(...rating.map(user => user.deaths || 0));
+});
+
+const maxKdRatio = computed(() => {
+  if (!rating?.length) return 0;
+  return Math.max(...rating.map(user => user.deaths ? (user.kills / user.deaths) : 0));
+});
+
+const maxFoodEaten = computed(() => {
+  if (!rating?.length) return 0;
+  return Math.max(...rating.map(user => user.foodEaten || 0));
+});
 </script>
 
 <template>
@@ -136,16 +157,16 @@ const isModalOpen = ref(false);
               <td class="px-6 py-4">
                 {{ userRating.gamesPlayed }}
               </td>
-              <td class="px-6 py-4 bg-gray-50 dark:bg-gray-800">
+              <td class="px-6 py-4 bg-gray-50 dark:bg-gray-800" :class="{ 'font-bold': userRating.kills === maxKills }">
                 {{ userRating.kills }}
               </td>
-              <td class="px-6 py-4">
+              <td class="px-6 py-4" :class="{ 'font-bold': userRating.deaths === maxDeaths }">
                 {{ userRating.deaths }}
               </td>
-              <td class="px-6 py-4 bg-gray-50 dark:bg-gray-800">
+              <td class="px-6 py-4 bg-gray-50 dark:bg-gray-800" :class="{ 'font-bold': userRating.deaths && (userRating.kills / userRating.deaths) === maxKdRatio }">
                 {{ userRating.deaths ? (userRating.kills / userRating.deaths).toFixed(2) : "n/a" }}
               </td>
-              <td class="px-6 py-4">
+              <td class="px-6 py-4" :class="{ 'font-bold': userRating.foodEaten === maxFoodEaten }">
                 {{ userRating.foodEaten }}
               </td>
               <td class="px-6 py-4 bg-gray-50 dark:bg-gray-800">


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `claude-code@0.2.35` ran with:

```sh
claude
```

Then, we accepted all the suggestions that Claude made until it was done.

Prompt:
> Please, solve the following issue. Title: feat(rating): highlight top results in k/d, kills, deaths, and food eaten columns in the rating table. Description: Let's make them bold.

Cost: $0.1175 USD.

## Notes

The direction makes sense, but the class isn't being applied to any result in the rating table because it didn't account for the fact that `rating` is a ref object.

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/23eeb0ff-849d-4adb-93a6-8af33eabba75" />

## Checklist

- [x] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
