### PR TITLE
[Claude Code] [Claude 3.7] [$0.53] feat: add code version history with restore functionality

### DIFF
--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -33,6 +33,7 @@ const state = reactive({
   code: user.value?.body.code || defaultCode,
   codeHasErrors: false,
   showAPIReference: false,
+  showVersionHistory: false,
 });
 
 function onSubmit(event: Event) {
@@ -57,6 +58,24 @@ function onShowAPIReferenceClick() {
 function onCloseAPIReferenceModal() {
   state.showAPIReference = false;
 }
+
+function onShowVersionHistoryClick() {
+  state.showVersionHistory = true;
+}
+
+function onCloseVersionHistoryModal() {
+  state.showVersionHistory = false;
+}
+
+function onRevertToVersion() {
+  // Refresh the user code after reversion
+  fetch("/api/auth/user").then(async (response) => {
+    if (response.ok) {
+      const data = await response.json();
+      state.code = data.body.code;
+    }
+  });
+}
 </script>
 
 <template>
@@ -70,6 +89,9 @@ function onCloseAPIReferenceModal() {
     >
       <div class="flex flex-grow flex-col shadow mb-4">
         <div class="flex flex-row justify-end mb-2 mt-1 mx-2 gap-6">
+          <ButtonLink @click="onShowVersionHistoryClick">
+            code history
+          </ButtonLink>
           <ButtonLink @click="onRestoreDefaultCodeClick">
             restore example code
           </ButtonLink>
@@ -98,6 +120,8 @@ function onCloseAPIReferenceModal() {
       </div>
     </form>
   </div>
+
+  <!-- API Reference Modal -->
   <ModalDialog
     :open="state.showAPIReference"
     :on-close="onCloseAPIReferenceModal"
@@ -117,4 +141,11 @@ function onCloseAPIReferenceModal() {
       class="flex-grow"
     />
   </ModalDialog>
+
+  <!-- Version History Modal -->
+  <CodeVersionHistoryModal
+    :open="state.showVersionHistory"
+    :on-close="onCloseVersionHistoryModal"
+    @revert="onRevertToVersion"
+  />
 </template>

--- a/components/CodeVersionHistoryModal.vue
+++ b/components/CodeVersionHistoryModal.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+const props = defineProps<{ 
+  open: boolean; 
+  onClose: () => void;
+}>();
+
+const emit = defineEmits<{
+  revert: [timestamp: number]
+}>();
+
+interface Version {
+  timestamp: number;
+  date: string;
+  id: string;
+}
+
+const state = reactive({
+  versions: [] as Version[],
+  selectedVersion: null as Version | null,
+  selectedVersionCode: '',
+  loading: true,
+  error: '',
+});
+
+watch(() => props.open, async (isOpen) => {
+  if (isOpen) {
+    try {
+      state.loading = true;
+      state.error = '';
+      state.selectedVersion = null;
+      state.selectedVersionCode = '';
+      
+      // Load versions list
+      const response = await fetch('/api/bot/versions');
+      if (!response.ok) throw new Error('Failed to load versions');
+      
+      state.versions = await response.json();
+    } catch (error) {
+      state.error = error instanceof Error ? error.message : 'An error occurred';
+    } finally {
+      state.loading = false;
+    }
+  }
+});
+
+async function selectVersion(version: Version) {
+  try {
+    state.loading = true;
+    state.error = '';
+    state.selectedVersion = version;
+    
+    // Load selected version code
+    const response = await fetch(`/api/bot/version/${version.timestamp}`);
+    if (!response.ok) throw new Error('Failed to load version');
+    
+    const data = await response.json();
+    state.selectedVersionCode = data.code;
+  } catch (error) {
+    state.error = error instanceof Error ? error.message : 'An error occurred';
+  } finally {
+    state.loading = false;
+  }
+}
+
+async function revertToVersion() {
+  if (!state.selectedVersion) return;
+  
+  try {
+    state.loading = true;
+    state.error = '';
+    
+    // Revert to selected version
+    const response = await fetch('/api/bot/version/revert', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ timestamp: state.selectedVersion.timestamp }),
+    });
+    
+    if (!response.ok) throw new Error('Failed to revert to version');
+    
+    emit('revert', state.selectedVersion.timestamp);
+    props.onClose();
+  } catch (error) {
+    state.error = error instanceof Error ? error.message : 'An error occurred';
+  } finally {
+    state.loading = false;
+  }
+}
+</script>
+
+<template>
+  <ModalDialog
+    :open="open"
+    :on-close="onClose"
+    extra-modal-class="w-[900px]"
+  >
+    <div class="flex flex-col h-full" v-if="state.loading && !state.versions.length">
+      <div class="flex items-center justify-center h-full">
+        <span>Loading versions...</span>
+      </div>
+    </div>
+    
+    <div class="flex flex-col h-full" v-else-if="state.error && !state.versions.length">
+      <div class="flex items-center justify-center h-full">
+        <span class="text-red-500">{{ state.error }}</span>
+      </div>
+    </div>
+    
+    <div class="flex flex-col h-full" v-else-if="!state.versions.length">
+      <div class="flex items-center justify-center h-full">
+        <span>No previous versions found.</span>
+      </div>
+    </div>
+    
+    <div class="flex h-full" v-else>
+      <!-- Version code preview -->
+      <div class="w-2/3 h-full pr-4 border-r">
+        <div v-if="!state.selectedVersion" class="flex items-center justify-center h-full">
+          <span class="text-gray-500">Select a version to preview</span>
+        </div>
+        
+        <div v-else-if="state.loading" class="flex items-center justify-center h-full">
+          <span>Loading code...</span>
+        </div>
+        
+        <div v-else class="h-full flex flex-col">
+          <div class="flex justify-between mb-2">
+            <h3 class="font-medium">Version from {{ state.selectedVersion.date }}</h3>
+            <button
+              @click="revertToVersion"
+              class="px-3 py-1 text-sm bg-blue-500 hover:bg-blue-600 text-white"
+            >
+              Restore this version
+            </button>
+          </div>
+          <MonacoEditor
+            v-model="state.selectedVersionCode"
+            lang="javascript"
+            class="flex-grow"
+            :options="{
+              readOnly: true,
+              scrollBeyondLastLine: false,
+              minimap: { enabled: false },
+              smoothScrolling: true,
+            }"
+          />
+        </div>
+      </div>
+      
+      <!-- Versions list -->
+      <div class="w-1/3 h-full pl-4 overflow-y-auto">
+        <h3 class="font-medium mb-3">Code history</h3>
+        
+        <div v-if="state.error" class="text-red-500 mb-3">
+          {{ state.error }}
+        </div>
+        
+        <ul class="space-y-2">
+          <li
+            v-for="version in state.versions"
+            :key="version.timestamp"
+            @click="selectVersion(version)"
+            class="p-2 border cursor-pointer hover:bg-gray-50"
+            :class="{ 'bg-blue-50 border-blue-300': state.selectedVersion?.timestamp === version.timestamp }"
+          >
+            <div class="text-sm">
+              {{ version.date }}
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </ModalDialog>
+</template>

--- a/other/botCodeStore.ts
+++ b/other/botCodeStore.ts
@@ -1,5 +1,6 @@
 import EventEmitter from "node:events";
 import fs from "node:fs";
+import path from "node:path";
 
 const BOT_CODE_DIR = process.env.BOT_CODE_DIR || "./bot-code";
 
@@ -8,11 +9,18 @@ export interface BotCode {
   code: string;
   username: string;
   userId: number;
+  timestamp?: number;
 }
 
+export type BotCodeVersion = BotCode & {
+  timestamp: number;
+};
+
 export type BotCodes = Record<string, BotCode>;
+export type BotCodeVersions = Record<string, BotCodeVersion[]>;
 
 let STORE: BotCodes = {};
+let VERSIONS_STORE: BotCodeVersions = {};
 
 const botEventEmitter = new EventEmitter();
 
@@ -23,12 +31,28 @@ type SubmitBotCodeArgs = {
 };
 
 export function submitBotCode({ code, username, userId }: SubmitBotCodeArgs) {
-  // ensure each user has only one bot
+  // ensure each user has only one active bot
   const id = Object.values(STORE).find(botCode => botCode.username === username)?.id || Math.random().toString(36).substring(5);
+  const timestamp = Date.now();
   const botCode = { id, code, username, userId };
+  const versionedBotCode = { ...botCode, timestamp };
+
+  // Add to the main store (current version)
   STORE[id] = botCode;
+  
+  // Add to versions store
+  if (!VERSIONS_STORE[username]) {
+    VERSIONS_STORE[username] = [];
+  }
+  VERSIONS_STORE[username].push(versionedBotCode);
+  
+  // Save both the current version and the versioned file
   saveBot(botCode);
+  saveVersionedBot(versionedBotCode);
+  
+  // Notify subscribers
   botEventEmitter.emit("update", STORE);
+  botEventEmitter.emit("version-update", VERSIONS_STORE);
 }
 
 export function clearBots() {
@@ -39,9 +63,39 @@ export function getBots() {
   return { ...STORE };
 }
 
+export function getBotVersions(username: string): BotCodeVersion[] {
+  return [...(VERSIONS_STORE[username] || [])].sort((a, b) => b.timestamp - a.timestamp);
+}
+
+export function getLatestBotVersion(username: string): BotCodeVersion | null {
+  const versions = getBotVersions(username);
+  return versions.length > 0 ? versions[0] : null;
+}
+
+export function revertToBotVersion(username: string, versionTimestamp: number): boolean {
+  const version = VERSIONS_STORE[username]?.find(v => v.timestamp === versionTimestamp);
+  if (!version) return false;
+  
+  // Update current version with the code from the selected version
+  const currentBot = Object.values(STORE).find(bot => bot.username === username);
+  if (currentBot) {
+    currentBot.code = version.code;
+    saveBot(currentBot);
+    botEventEmitter.emit("update", STORE);
+    return true;
+  }
+  
+  return false;
+}
+
 export function subscribeToBotsUpdate(onUpdate: (bots: BotCodes) => void): () => void {
   botEventEmitter.on("update", onUpdate);
   return () => botEventEmitter.off("update", onUpdate);
+}
+
+export function subscribeToVersionsUpdate(onUpdate: (versions: BotCodeVersions) => void): () => void {
+  botEventEmitter.on("version-update", onUpdate);
+  return () => botEventEmitter.off("version-update", onUpdate);
 }
 
 function loadBots() {
@@ -50,16 +104,66 @@ function loadBots() {
   }
 
   const files = fs.readdirSync(BOT_CODE_DIR);
-
+  
+  // Load regular bot files and versioned bot files
   for (const file of files) {
-    const code = fs.readFileSync(`${BOT_CODE_DIR}/${file}`, "utf8");
-    const username = file.split("-")[0];
-    const id = file.split("-")[1];
-    const userId = file.split("-")[2]?.replace(".js", "");
-    if (!id || !code || !username || !userId) {
-      throw new Error(`Invalid bot code file: ${file}`);
+    if (file.includes('-latest.js')) {
+      // Skip the latest file as it's just a duplicate for easy access
+      continue;
     }
-    STORE[id] = { id, code, username, userId: +userId };
+    
+    try {
+      const code = fs.readFileSync(path.join(BOT_CODE_DIR, file), "utf8");
+      
+      // Check if this is a versioned file (has timestamp)
+      if (file.match(/\d{13}\.js$/)) {
+        const parts = file.split("-");
+        const username = parts[0];
+        const id = parts[1];
+        const timestampStr = parts[2].replace(".js", "");
+        const timestamp = parseInt(timestampStr, 10);
+        const userId = file.split("-")[3]?.replace(".js", "");
+        
+        if (!id || !code || !username || !userId || isNaN(timestamp)) {
+          console.error(`Invalid versioned bot code file: ${file}`);
+          continue;
+        }
+        
+        const versionedBotCode = { id, code, username, userId: +userId, timestamp };
+        
+        if (!VERSIONS_STORE[username]) {
+          VERSIONS_STORE[username] = [];
+        }
+        VERSIONS_STORE[username].push(versionedBotCode);
+        
+        // Also add the most recent version to the main store
+        const existingVersion = VERSIONS_STORE[username]
+          .sort((a, b) => b.timestamp - a.timestamp)[0];
+        
+        if (existingVersion) {
+          STORE[existingVersion.id] = {
+            id: existingVersion.id,
+            code: existingVersion.code,
+            username: existingVersion.username,
+            userId: existingVersion.userId
+          };
+        }
+      } else {
+        // Regular bot file
+        const username = file.split("-")[0];
+        const id = file.split("-")[1];
+        const userId = file.split("-")[2]?.replace(".js", "");
+        
+        if (!id || !code || !username || !userId) {
+          console.error(`Invalid bot code file: ${file}`);
+          continue;
+        }
+        
+        STORE[id] = { id, code, username, userId: +userId };
+      }
+    } catch (error) {
+      console.error(`Error loading bot file ${file}:`, error);
+    }
   }
 }
 
@@ -67,9 +171,24 @@ function saveBot({ id, code, username, userId }: BotCode) {
   if (!fs.existsSync(BOT_CODE_DIR)) {
     fs.mkdirSync(BOT_CODE_DIR);
   }
+  
+  // Regular bot file
   const botCodeFile = `${BOT_CODE_DIR}/${username}-${id}-${userId}.js`;
-
   fs.writeFileSync(botCodeFile, code);
+  
+  // Latest bot file (for easy access)
+  const latestBotCodeFile = `${BOT_CODE_DIR}/${username}-latest.js`;
+  fs.writeFileSync(latestBotCodeFile, code);
+}
+
+function saveVersionedBot({ id, code, username, userId, timestamp }: BotCodeVersion) {
+  if (!fs.existsSync(BOT_CODE_DIR)) {
+    fs.mkdirSync(BOT_CODE_DIR);
+  }
+  
+  // Version with timestamp
+  const versionedBotCodeFile = `${BOT_CODE_DIR}/${username}-${id}-${timestamp}-${userId}.js`;
+  fs.writeFileSync(versionedBotCodeFile, code);
 }
 
 loadBots();

--- a/server/api/bot/submit.post.ts
+++ b/server/api/bot/submit.post.ts
@@ -24,7 +24,7 @@ export default defineEventHandler(async (event) => {
   if (!result.success) {
     throw createError({
       statusCode: HTTP_STATUS_CODES.UNPROCESSABLE_ENTITY,
-      statusMessage: "Username and password field is required",
+      statusMessage: "Code field is required",
     });
   }
 

--- a/server/api/bot/version/[timestamp].get.ts
+++ b/server/api/bot/version/[timestamp].get.ts
@@ -1,0 +1,39 @@
+import * as botCodeStore from "~/other/botCodeStore";
+import { HTTP_STATUS_CODES } from "~/other/httpStatusCodes";
+
+export default defineEventHandler(async (event) => {
+  const username = event.context.user.username;
+  const timestampParam = event.context.params?.timestamp;
+  
+  if (!timestampParam) {
+    throw createError({
+      statusCode: HTTP_STATUS_CODES.BAD_REQUEST,
+      statusMessage: "Version timestamp is required",
+    });
+  }
+  
+  const timestamp = parseInt(timestampParam, 10);
+  
+  if (isNaN(timestamp)) {
+    throw createError({
+      statusCode: HTTP_STATUS_CODES.BAD_REQUEST,
+      statusMessage: "Invalid timestamp format",
+    });
+  }
+  
+  const versions = botCodeStore.getBotVersions(username);
+  const version = versions.find(v => v.timestamp === timestamp);
+  
+  if (!version) {
+    throw createError({
+      statusCode: HTTP_STATUS_CODES.NOT_FOUND,
+      statusMessage: "Version not found",
+    });
+  }
+  
+  return {
+    code: version.code,
+    timestamp: version.timestamp,
+    date: new Date(version.timestamp).toLocaleString(),
+  };
+});

--- a/server/api/bot/version/revert.post.ts
+++ b/server/api/bot/version/revert.post.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import * as botCodeStore from "~/other/botCodeStore";
+import { HTTP_STATUS_CODES } from "~/other/httpStatusCodes";
+
+const revertSchema = z.object({
+  timestamp: z.number(),
+});
+
+export default defineEventHandler(async (event) => {
+  const username = event.context.user.username;
+  
+  const result = await readValidatedBody(event, body => revertSchema.safeParse(body));
+  if (!result.success) {
+    throw createError({
+      statusCode: HTTP_STATUS_CODES.UNPROCESSABLE_ENTITY,
+      statusMessage: "Timestamp field is required",
+    });
+  }
+  
+  const { timestamp } = result.data;
+  const success = botCodeStore.revertToBotVersion(username, timestamp);
+  
+  if (!success) {
+    throw createError({
+      statusCode: HTTP_STATUS_CODES.NOT_FOUND,
+      statusMessage: "Version not found",
+    });
+  }
+  
+  return {
+    status: "reverted",
+    timestamp,
+  };
+});

--- a/server/api/bot/versions.get.ts
+++ b/server/api/bot/versions.get.ts
@@ -1,0 +1,15 @@
+import * as botCodeStore from "~/other/botCodeStore";
+
+export default defineEventHandler(async (event) => {
+  const username = event.context.user.username;
+  const versions = botCodeStore.getBotVersions(username);
+  
+  // Format the versions data for the frontend
+  const formattedVersions = versions.map(version => ({
+    timestamp: version.timestamp,
+    date: new Date(version.timestamp).toLocaleString(),
+    id: version.id,
+  }));
+  
+  return formattedVersions;
+});


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `claude` ran with:

```sh
claude
```

Prompt:
> Please, solve the following issue. Title: feat: add code versions and an option to revert to a previous version. Description: **Goal:** let the user revert to the previous code version
> Proposed implementation:
> - every time the user submits code, store it separately, don't overwrite the previous code version
>     - we can use filenames with dates in them, for example: `<userid>-<timestamp>.js`
>     - use a special name, like `<userid>-latest.js` for the latest code version so we can quickly retrieve it by path
> - add a modal that will allow the user to view previous submissions in the UI and revert to them
>     - the button to open a modal should be above the code editor
>     - the modal left side should be occupied by the read-only code editor
>     - the modal on the right side should be occupied by the list of versions
>     - user can click any of the versions to preview them in the modal
>     - user can click the restore button to restore the version
>     - restoring the code doesn't create a new version until the user submits the code again
> Let me know if you want to work on this ticket and if you have any questions!

Cost: $0.53 USD.

## Limitations

<!-- Anything related to this PR that wasn't "done" in this PR -->

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
