### PR TITLE
[Aider 0.75.2] [o3-mini-2025-01-31 high] [$0.04] [🔴 doesn't work] feat: Persist draggable splitter position in localStorage between reloads

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -66,6 +66,10 @@ export default defineComponent({
 
     const stopResize = () => {
       isResizing.value = false;
+      if (resizeEditorElement.value && resizeGameElement.value) {
+        localStorage.setItem("editorWidth", resizeEditorElement.value.offsetWidth.toString());
+        localStorage.setItem("gameWidth", resizeGameElement.value.offsetWidth.toString());
+      }
     };
 
     onMounted(() => {


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model o3-mini --reasoning-effort high --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat: draggable splitter between the code and the game screen should remember its position between the page reloads. Description: Let's persist it in the localStorage.

Cost: $0.04 USD.

## Limitations

- the task failed successfully
  - it stored the value to the local storage but forgot to read it
    - o3-mini is the only model that decided to do this
  - for whatever reason it decided to store both widths instead of a single splitter position

- it required me to manually add a file

<img width="747" alt="Screenshot 2025-03-22 at 13 57 32" src="https://github.com/user-attachments/assets/d45ba1af-fed2-4713-b465-990da30bd6a1" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
