### PR TITLE
[Aider] [o3-mini-high] [$0.07] feat(rating): add submission count column to rating table and API response

### DIFF
--- a/Create a new migration file to add the submissionCount column:
+++ b/Create a new migration file to add the submissionCount column:
@@ -1,0 +1,2 @@
+-- Migration: Add submissionCount column to User table for tracking code submissions
+ALTER TABLE "User" ADD COLUMN "submissionCount" INTEGER NOT NULL DEFAULT 0;

--- a/pages/rating.vue
+++ b/pages/rating.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col h-screen w-screen">
     <GlobalHeader subtitle="rating" />
-    <RatingTable />
+    <RatingTable :showSubmissionCount="true" />
   </div>
 </template>

--- a/server/api/bot/submit.post.ts
+++ b/server/api/bot/submit.post.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import * as botCodeStore from "~/other/botCodeStore";
 import { HTTP_STATUS_CODES } from "~/other/httpStatusCodes";
 import { SUBMIT_COOLDOWN_MS } from "~/other/submitApiRatelimitConstants";
+import prisma from "~/other/db";
 
 const submitBotCodeSchema = z.object({
   code: z.string(),
@@ -35,6 +36,11 @@ export default defineEventHandler(async (event) => {
   });
 
   RATELIMITER.set(event.context.user.id, true);
+
+  await prisma.user.update({
+    where: { id: event.context.user.id },
+    data: { submissionCount: { increment: 1 } },
+  });
 
   return { status: "submitted" };
 });

--- a/server/api/rating.get.ts
+++ b/server/api/rating.get.ts
@@ -14,6 +14,7 @@ type UserStats = {
 export type UserRating = UserStats & {
   userId: number;
   username: string;
+  submissionCount: number;
   score7days: number;
   score24hours: number;
   score1hour: number;
@@ -152,6 +153,7 @@ export default defineEventHandler(async () => {
       ...rawUserStat.stats7days,
       userId: rawUserStat.userId,
       username: rawUserStat.username,
+      submissionCount: users.find(user => user.id === rawUserStat.userId)?.submissionCount ?? 0,
       maxEndgameSize: Math.max(...rawUserStat.stats7days.endgameSizes),
       avgEndgameSize: (
         rawUserStat.stats7days.endgameSizes.reduce((acc, size) => acc + size, 0)


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model o3-mini --reasoning-effort high --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat(rating): add a new column to the rating table displaying the number of times the user submitted the code. Description: add a way for us to track how many times the user submitted the code
> return the number to the client with the game stats
> display it in the rating table

Cost: $0.07 USD.

## Limitations

- I had to manually add source code files to the session

<img width="748" alt="Screenshot 2025-03-22 at 14 20 52" src="https://github.com/user-attachments/assets/56fd4a33-efce-4fbd-a5da-29259c3b2c1a" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
