### PR TITLE
[Aider 0.75.2] [o3-mini-2025-01-31 high] [$0.22] [🔴 doesn't work] feat(sandbox): add toggle to switch between sprites and circles for debugging

### DIFF
--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -9,6 +9,10 @@ const minZoom = 1;
 const maxZoom = 3;
 const isFollowing = ref<boolean>(false);
 const zoomInToPlayerOrResetZoomFn = ref<(() => void) | null>(null);
+const useCircles = ref<boolean>(false);
+function toggleUseCircles() {
+  useCircles.value = !useCircles.value;
+}
 
 const { data: gameState, refresh } = await useFetch("/api/state");
 const intervalRef = ref<number | null>(null);
@@ -415,6 +419,12 @@ watch(gameState, async (newState, prevState) => {
           @click="toggleFollowMeMode"
         >
           {{ isFollowing ? "stop following my bot" : "follow my bot" }}
+        </ButtonLink>
+        <ButtonLink
+          v-if="user?.body"
+          @click="toggleUseCircles"
+        >
+          {{ useCircles ? "Switch to Sprites" : "Switch to Circles" }}
         </ButtonLink>
       </div>
       <canvas ref="canvas" />


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model o3-mini --reasoning-effort high --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat(sandbox): add an option to turn off sprites and replace them with circles to make debugging easier. Description: It would be helpful to have a toggle that replaces fish sprites on the Game Screen with circles to avoid getting distracted by uneven sprite shapes when debugging.

Cost: $0.22 USD.

## Notes

https://github.com/user-attachments/assets/025a59f1-4bd9-4488-99ca-26dcb4bf1cf8

- it made me give it the files manually

<img width="747" alt="Screenshot 2025-03-22 at 14 25 17" src="https://github.com/user-attachments/assets/fc2bb9ed-872c-4ca5-902b-8d66b811c034" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
