### PR TITLE
[Aider 0.75.2] [o3-mini-2025-01-31 high] [$0.08] [🔴 doesn't work] feat: add code versioning and revert functionality in the editor

### DIFF
--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { defaultCode, jsdoc } from "~/other/defaultCode.js";
+import CodeVersionModal from "~/components/CodeVersionModal.vue";
 
 if (import.meta.client) {
   // configure monaco editor on client side
@@ -33,6 +34,7 @@ const state = reactive({
   code: user.value?.body.code || defaultCode,
   codeHasErrors: false,
   showAPIReference: false,
+  showCodeVersions: false,
 });
 
 function onSubmit(event: Event) {
@@ -57,6 +59,19 @@ function onShowAPIReferenceClick() {
 function onCloseAPIReferenceModal() {
   state.showAPIReference = false;
 }
+
+function onShowCodeVersionsClick() {
+  state.showCodeVersions = true;
+}
+
+function onCloseCodeVersionsModal() {
+  state.showCodeVersions = false;
+}
+
+function onRevertVersion(code: string) {
+  state.code = code;
+  state.showCodeVersions = false;
+}
 </script>
 
 <template>
@@ -75,6 +90,9 @@ function onCloseAPIReferenceModal() {
           </ButtonLink>
           <ButtonLink @click="onShowAPIReferenceClick">
             API reference
+          </ButtonLink>
+          <ButtonLink @click="onShowCodeVersionsClick">
+            Code Versions
           </ButtonLink>
         </div>
         <MonacoEditor
@@ -117,4 +135,9 @@ function onCloseAPIReferenceModal() {
       class="flex-grow"
     />
   </ModalDialog>
+  <CodeVersionModal
+    v-if="state.showCodeVersions"
+    @close="onCloseCodeVersionsModal"
+    @revert="onRevertVersion"
+  />
 </template>

--- a/components/CodeVersionModal.vue
+++ b/components/CodeVersionModal.vue
@@ -1,0 +1,86 @@
+<template>
+  <ModalDialog :open="true" :on-close="onClose" extra-modal-class="w-[80vw] h-[80vh]">
+    <div class="flex h-full">
+      <div class="w-2/3 border-r p-4">
+        <MonacoEditor
+          v-model="previewCode"
+          lang="javascript"
+          :options="{
+            readOnly: true,
+            readOnlyMessage: { value: 'This version is read-only' },
+            lineNumbers: 'off',
+            smoothScrolling: true,
+            scrollBeyondLastLine: false,
+            minimap: { enabled: false },
+          }"
+          class="h-full"
+        />
+      </div>
+      <div class="w-1/3 p-4 flex flex-col">
+        <div class="flex-grow overflow-y-auto">
+          <ul>
+            <li
+              v-for="version in versions"
+              :key="version.filename"
+              class="border p-2 my-1 cursor-pointer hover:bg-gray-100"
+              @click="selectVersion(version)"
+            >
+              <div>{{ version.filename }}</div>
+              <div class="text-sm text-gray-600">{{ formatTimestamp(version.timestamp) }}</div>
+            </li>
+          </ul>
+        </div>
+        <div class="mt-4">
+          <button
+            @click="restoreVersion"
+            class="w-full py-2 px-4 bg-blue-500 text-white rounded hover:bg-blue-600"
+            :disabled="!previewCode"
+          >
+            Restore
+          </button>
+        </div>
+      </div>
+    </div>
+  </ModalDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+const emit = defineEmits<{
+  (e: "close"): void;
+  (e: "revert", code: string): void;
+}>();
+
+const versions = ref<Array<{ filename: string; timestamp: number; code: string }>>([]);
+const previewCode = ref("");
+
+// Fetch versions from an API endpoint on mount
+onMounted(async () => {
+  try {
+    const res = await fetch("/api/bot/versions");
+    const data = await res.json();
+    versions.value = data.versions;
+    if (versions.value.length > 0) {
+      previewCode.value = versions.value[0].code;
+    }
+  } catch (e) {
+    console.error("Failed to fetch code versions", e);
+  }
+});
+
+function selectVersion(version: { filename: string; timestamp: number; code: string }) {
+  previewCode.value = version.code;
+}
+
+function restoreVersion() {
+  emit("revert", previewCode.value);
+}
+
+function onClose() {
+  emit("close");
+}
+
+function formatTimestamp(ts: number): string {
+  return new Date(ts).toLocaleString();
+}
+</script>


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model o3-mini --reasoning-effort high --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat: add code versions and an option to revert to a previous version. Description: **Goal:** let the user revert to the previous code version
> Proposed implementation:
> - every time the user submits code, store it separately, don't overwrite the previous code version
>     - we can use filenames with dates in them, for example: `<userid>-<timestamp>.js`
>     - use a special name, like `<userid>-latest.js` for the latest code version so we can quickly retrieve it by path
> - add a modal that will allow the user to view previous submissions in the UI and revert to them
>     - the button to open a modal should be above the code editor
>     - the modal left side should be occupied by the read-only code editor
>     - the modal on the right side should be occupied by the list of versions
>     - user can click any of the versions to preview them in the modal
>     - user can click the restore button to restore the version
>     - restoring the code doesn't create a new version until the user submits the code again
> Let me know if you want to work on this ticket and if you have any questions!

Cost: $0.08 USD.

## Notes

- lacks understanding of the code

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
