### PR TITLE
[Aider 0.75.2] [o3-mini-2025-01-31 high] [$0.07] [🔴 doesn't work] feat: surface bot execution errors to the user

### DIFF
--- a/server/api/state.get.ts
+++ b/server/api/state.get.ts
@@ -8,6 +8,7 @@ export default defineEventHandler(async () => {
 
   return {
     ...gameState,
+    errorStack: WORLD_REF.world.playerBotError,
     bots: Object.fromEntries([...gameState.bots.entries()].map(([id, bot]) => {
       const botCode = botCodes[bot.botId];
       if (!botCode) {

--- a/server/plugins/engine.ts
+++ b/server/plugins/engine.ts
@@ -62,8 +62,10 @@ async function runBots({ bots, world, prevBotState, botApi }: RunBotArgs) {
       const result = await codeRunner.runCode(preparedCode);
       return JSON.parse(result);
     } catch (err) {
-      // TODO(yurij): notify user that their bot crashed
       console.error(err);
+      if (bot.username === 'player') {
+        WORLD_REF.world.playerBotError = err?.stack || String(err);
+      }
       return [];
     } finally {
       botCodeRunTimeMs.observe({ username: bot.username }, Date.now() - botCodeRuntimeStartTs);


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model o3-mini --reasoning-effort high --yes-always --no-check-update
```

Prompt:
> Please, solve the following issue. Title: feat: surface bot execution errors to the user. Description: **Goal:** If the bot crashed, we should display this to the user and show the error that caused the crash.
> It crashes here: aibyss/server/plugins/engine.ts
> Lines 52 to 53 in c0af374
> 
> |     |                                                    |
> | --- | -------------------------------------------------- |
> |     | // TODO(yurij): notify user that their bot crashed |
> |     | console.log(err);                                  |
> 
> This error:
> - needs to be captured and attached to the `state` returned by `state.get.ts`
>     - let’s add a new `errorStack` field at the top level of the object returned by `state.get.ts`. This field can either be absent if there’s no error, or contain a string with the error’s stack trace.
> - if it’s not `undefined`, display it below the code editing field and above the submit button. The code editing field can be slightly reduced in size if an error occurs.
> **Important considerations:**
> - Only return the error related to the player’s bot; do not return errors for all bots that have crashed.
>     - This isn’t useful for the interface and will bloat the `state` object.
> - In the interface, the error should be displayed in such a way that:
>     - Even if it’s very long, it should not cover the entire code editor – it should have a maximum height and be scrollable.
>     - The frontend updates state every second – if the same error keeps appearing, it should not flicker in the interface.
>     - Sometimes errors occur intermittently; for example, there might be several logical branches in the bot’s code and only one branch causes a crash.
>         - We need to ensure the interface does not flicker if the error disappears and reappears.
>         - To solve this, we’ll hide the error from the interface only after the user manually dismisses it (we need to add a close button to the error window). This way, even if the crash happens once a minute, the user a) will see it and b) will have time to study the error calmly and fix it.
> **What we are not doing in this PR:**
> - Streaming errors via websockets – not needed right now, since we continuously update the game state, and the user will still get the latest error. Let’s just use the existing `/state` API to return it.
>     - **Why:** Simplicity and time-saving. From the user’s perspective, the result is the same. If we encounter issues with this, we’ll address them in a separate PR – not in this one.
> - Returning an array of errors or all errors that occurred – we will return only the current error if it exists. The interface can then decide what to do with it and how to display it.
>     - **Why:** Simplicity. No need to consider error history, etc. It won’t significantly affect the user experience for this PR. In 99% of cases, the bot will crash repeatedly in the same way, returning the same single error.
> - Persisting errors
>     - It’s enough to store them in the application’s memory since these are ephemeral data – they have no special value after a restart. If the bot crashes, it will crash again after a restart, and the user will see the error.
> **The focus of this PR is to:**
> - Capture the current error, if any, and include it in `state` in the simplest and quickest way.
> - Display it neatly in the interface – so that the error helps the user rather than getting in their way.

Cost: $0.07 USD.

## Notes

- it didn't make any changes to the UI
- it doesn't track bot errors separately (e.g., if two bots fail, then we only store the second failure)
- it returns any bot failure to all of the users on the API

- I had to add the file manually once

<img width="750" alt="Screenshot 2025-03-22 at 14 45 53" src="https://github.com/user-attachments/assets/03b37629-612d-42c8-b3ec-f960518d60d3" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
