### PR TITLE
[Aider] [Claude 3.7 32k think tokens] [$0.20] feat: Add draggable splitter with localStorage position persistence

### DIFF
--- a/composables/useSplitterPosition.ts
+++ b/composables/useSplitterPosition.ts
@@ -1,0 +1,31 @@
+import { ref, onMounted, watch } from 'vue';
+
+export function useSplitterPosition(defaultPosition: number = 50) {
+  const STORAGE_KEY = 'splitter-position';
+  const position = ref(defaultPosition);
+
+  // Load position from localStorage on mount
+  onMounted(() => {
+    try {
+      const savedPosition = localStorage.getItem(STORAGE_KEY);
+      if (savedPosition !== null) {
+        position.value = Number(savedPosition);
+      }
+    } catch (error) {
+      console.error('Failed to load splitter position from localStorage:', error);
+    }
+  });
+
+  // Save position to localStorage when it changes
+  watch(position, (newPosition) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(newPosition));
+    } catch (error) {
+      console.error('Failed to save splitter position to localStorage:', error);
+    }
+  });
+
+  return {
+    position,
+  };
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,6 +24,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, onMounted, onUnmounted } from "vue";
+import { useSplitterPosition } from '~/composables/useSplitterPosition';
 
 export default defineComponent({
   setup() {
@@ -34,6 +35,7 @@ export default defineComponent({
     const resizeEditorElement = ref<HTMLDivElement | null>(null);
     const resizeGameElement = ref<HTMLDivElement | null>(null);
     const separator = ref<HTMLDivElement | null>(null);
+    const { position } = useSplitterPosition(50); // default to 50% split
 
     const startResize = (e: MouseEvent) => {
       if (!resizeEditorElement.value) {
@@ -66,9 +68,26 @@ export default defineComponent({
 
     const stopResize = () => {
       isResizing.value = false;
+      
+      // Save the current position as percentage when resizing stops
+      if (resizeEditorElement.value && resizeGameElement.value) {
+        const totalWidth = resizeEditorElement.value.offsetWidth + resizeGameElement.value.offsetWidth;
+        const editorPercentage = (resizeEditorElement.value.offsetWidth / totalWidth) * 100;
+        position.value = editorPercentage;
+      }
     };
 
     onMounted(() => {
+      // Apply the saved position on mount
+      if (resizeEditorElement.value && resizeGameElement.value) {
+        const totalWidth = resizeEditorElement.value.offsetWidth + resizeGameElement.value.offsetWidth;
+        const editorWidth = (position.value / 100) * totalWidth;
+        const gameWidth = totalWidth - editorWidth;
+        
+        resizeEditorElement.value.style.width = `${editorWidth}px`;
+        resizeGameElement.value.style.width = `${gameWidth}px`;
+      }
+      
       if (!separator.value) {
         throw new Error("unexpected: no separator");
       }


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model anthropic/claude-3-7-sonnet-20250219 --yes-always
```

Prompt:
> Please, solve the following issue. Title: feat: draggable splitter between the code and the game screen should remember its position between the page reloads. Description: Let's persist it in the localStorage.

Cost: $0.20 USD.

## Notes



## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
