### PR TITLE
[Aider 0.78.0] [anthropic/claude-3-7-sonnet-20250219 + 32k think tokens] [$0.08] [🔴 doesn't work] feat: Add inactive user field and filter inactive bots

### DIFF
--- a/schema.prisma
+++ b/schema.prisma
@@ -11,6 +11,7 @@ model User {
   id        Int         @id @default(autoincrement())
   password  String
   username  String      @unique
+  inactive  Boolean     @default(false)
   game_stats GameStats[]
 }
 

--- a/server/api/bot/submit.post.ts
+++ b/server/api/bot/submit.post.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import * as botCodeStore from "~/other/botCodeStore";
 import { HTTP_STATUS_CODES } from "~/other/httpStatusCodes";
 import { SUBMIT_COOLDOWN_MS } from "~/other/submitApiRatelimitConstants";
+import { db } from "~/other/db";
 
 const submitBotCodeSchema = z.object({
   code: z.string(),
@@ -27,6 +28,12 @@ export default defineEventHandler(async (event) => {
       statusMessage: "Username and password field is required",
     });
   }
+
+  // Set the user's inactive status to false when they submit code
+  await db.user.update({
+    where: { id: event.context.user.id },
+    data: { inactive: false }
+  });
 
   botCodeStore.submitBotCode({
     username: event.context.user.username,


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model anthropic/claude-3-7-sonnet-20250219 --yes-always --thinking-tokens 32k
```

Prompt:
> Please, solve the following issue. Title: feat: allow turning off the bots of some users by setting the "inactive" field in the database on the user object to true. Description: add inactive boolean field to the database
> add logic that ignores that user bot if inactive=true (never load it, never process it)
> if that user submits the bot code, set inactive=false

Cost: $0.08 USD.

## Notes

The direction looks right, but it messed up the `db` import.

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
