### PR TITLE
[Aider 0.78.0] [anthropic/claude-3-7-sonnet-20250219 + 32k think tokens] [$0.08] [🔴 doesn't work] feat: Optimize game screen layout to dynamically fill available space

### DIFF
--- a/components/GameScreen.vue
+++ b/components/GameScreen.vue
@@ -188,6 +188,7 @@ watch(gameState, async (newState, prevState) => {
       antialias: true,
       resolution: 4,
       autoDensity: true,
+      resizeTo: gameScreen.value || undefined,
     });
 
     // Follow player bot
@@ -406,8 +407,7 @@ watch(gameState, async (newState, prevState) => {
   >
     <div
       ref="gameScreen"
-      class="flex flex-col shadow ml-2"
-      :style="{ maxWidth: gameState?.width + 'px' }"
+      class="flex flex-col shadow ml-2 w-full h-full"
     >
       <div class="flex flex-row justify-end mb-2 mt-1 mx-4 gap-6">
         <ButtonLink
@@ -417,7 +417,7 @@ watch(gameState, async (newState, prevState) => {
           {{ isFollowing ? "stop following my bot" : "follow my bot" }}
         </ButtonLink>
       </div>
-      <canvas ref="canvas" />
+      <canvas ref="canvas" class="w-full h-full object-contain" />
     </div>
   </div>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,7 @@
       />
       <div
         ref="resizeGameElement"
-        class="flex min-w-[300px] w-1/2 overflow-auto"
+        class="flex min-w-[300px] flex-grow overflow-auto"
       >
         <GameScreen />
       </div>
@@ -58,9 +58,8 @@ export default defineComponent({
       if (isResizing.value) {
         const dx = e.clientX - initialX.value;
         const newWidthEditor = initialWidthEditor.value + dx;
-        const newWidthGame = initialWidthGame.value - dx;
+        // Only set the editor width - the game screen will take the remaining space
         resizeEditorElement.value.style.width = `${newWidthEditor}px`;
-        resizeGameElement.value.style.width = `${newWidthGame}px`;
       }
     };
 


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model anthropic/claude-3-7-sonnet-20250219 --yes-always --thinking-tokens 32k
```

Prompt:
> Please, solve the following issue. Title: feat: ensure that the game screen occupies all available free space to the right of the code editor. The game screen should scale and occupy the available free space to the right of the code editor.

Cost: $0.08 USD.

## Notes

The game screen crashes shortly after start.

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/77ba4e4b-98d7-43f7-8290-10783a6b54f1" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
