### PR TITLE
[Aider 0.78.0] [anthropic/claude-3-7-sonnet-20250219 + 32k think tokens] [$0.10] [🔴 it didn't understand the problem] feat(rating): add code submissions tracking and display in rating table

### DIFF
--- a/components/RatingTable.vue
+++ b/components/RatingTable.vue
@@ -101,6 +101,12 @@ const isModalOpen = ref(false);
               >
                 avg endgame size
               </th>
+              <th
+                scope="col"
+                class="px-6 py-3 bg-gray-50 dark:bg-gray-800"
+              >
+                code submissions
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -153,6 +159,9 @@ const isModalOpen = ref(false);
               </td>
               <td class="px-6 py-4">
                 {{ userRating.avgEndgameSize.toFixed(2) }}
+              </td>
+              <td class="px-6 py-4 bg-gray-50 dark:bg-gray-800">
+                {{ userRating.codeSubmissions }}
               </td>
             </tr>
           </tbody>

--- a/schema.prisma
+++ b/schema.prisma
@@ -8,10 +8,11 @@ generator client {
 }
 
 model User {
-  id        Int         @id @default(autoincrement())
-  password  String
-  username  String      @unique
-  game_stats GameStats[]
+  id               Int         @id @default(autoincrement())
+  password         String
+  username         String      @unique
+  code_submissions Int         @default(0)
+  game_stats       GameStats[]
 }
 
 model Game {

--- a/server/api/bot/submit.post.ts
+++ b/server/api/bot/submit.post.ts
@@ -1,6 +1,7 @@
 import { LRUCache } from "lru-cache";
 import { z } from "zod";
 import * as botCodeStore from "~/other/botCodeStore";
+import prisma from "~/other/db";
 import { HTTP_STATUS_CODES } from "~/other/httpStatusCodes";
 import { SUBMIT_COOLDOWN_MS } from "~/other/submitApiRatelimitConstants";
 
@@ -32,6 +33,12 @@ export default defineEventHandler(async (event) => {
     username: event.context.user.username,
     userId: event.context.user.id,
     code: result.data.code,
+  });
+
+  // Update the user's code submission count
+  await prisma.user.update({
+    where: { id: event.context.user.id },
+    data: { code_submissions: { increment: 1 } },
   });
 
   RATELIMITER.set(event.context.user.id, true);


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran with:

```sh
aider --model anthropic/claude-3-7-sonnet-20250219 --yes-always --thinking-tokens 32k
```

Prompt:
> Please, solve the following issue. Title: feat(rating): add a new column to the rating table displaying the number of times the user submitted the code. Description: add a way for us to track how many times the user submitted the code
> return the number to the client with the game stats
> display it in the rating table

Cost: $0.10 USD.

## Notes

We expect it to display submissions for the past 7 days. Instead it wrote the code to display submissions in forever.

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
