### PR TITLE
[Aider 0.78.0] [anthropic/claude-3-7-sonnet-20250219 + 32k think tokens] [$0.12] [🔴 doesn't work] feat: add code versioning with ability to view and restore previous versions

### DIFF
--- a/components/CodeEditor.vue
+++ b/components/CodeEditor.vue
@@ -33,6 +33,7 @@ const state = reactive({
   code: user.value?.body.code || defaultCode,
   codeHasErrors: false,
   showAPIReference: false,
+  showVersionsModal: false,
 });
 
 function onSubmit(event: Event) {
@@ -57,6 +58,18 @@ function onShowAPIReferenceClick() {
 function onCloseAPIReferenceModal() {
   state.showAPIReference = false;
 }
+
+function onShowVersionsClick() {
+  state.showVersionsModal = true;
+}
+
+function onCloseVersionsModal() {
+  state.showVersionsModal = false;
+}
+
+function onRestoreVersion(code: string) {
+  state.code = code;
+}
 </script>
 
 <template>
@@ -72,6 +85,9 @@ function onCloseAPIReferenceModal() {
         <div class="flex flex-row justify-end mb-2 mt-1 mx-2 gap-6">
           <ButtonLink @click="onRestoreDefaultCodeClick">
             restore example code
+          </ButtonLink>
+          <ButtonLink @click="onShowVersionsClick">
+            previous versions
           </ButtonLink>
           <ButtonLink @click="onShowAPIReferenceClick">
             API reference
@@ -117,4 +133,10 @@ function onCloseAPIReferenceModal() {
       class="flex-grow"
     />
   </ModalDialog>
+  
+  <CodeVersionsModal
+    :open="state.showVersionsModal"
+    :on-close="onCloseVersionsModal"
+    @restore="onRestoreVersion"
+  />
 </template>

--- a/components/CodeVersionsModal.vue
+++ b/components/CodeVersionsModal.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue';
+import type { BotCodeVersion } from '~/other/botCodeStore';
+
+const props = defineProps<{
+  open: boolean;
+  onClose: () => void;
+}>();
+
+const emit = defineEmits<{
+  (e: 'restore', code: string): void;
+}>();
+
+const versions = ref<BotCodeVersion[]>([]);
+const selectedVersion = ref<BotCodeVersion | null>(null);
+const selectedVersionCode = ref<string>('');
+const loading = ref(true);
+
+async function loadVersions() {
+  loading.value = true;
+  try {
+    const response = await fetch('/api/bot/versions');
+    if (response.ok) {
+      const data = await response.json();
+      versions.value = data.versions;
+      
+      if (versions.value.length > 0) {
+        selectedVersion.value = versions.value[0];
+        selectedVersionCode.value = versions.value[0].code;
+      }
+    }
+  } catch (error) {
+    console.error('Error loading code versions:', error);
+  } finally {
+    loading.value = false;
+  }
+}
+
+function selectVersion(version: BotCodeVersion) {
+  selectedVersion.value = version;
+  selectedVersionCode.value = version.code;
+}
+
+function formatDate(timestamp: number) {
+  return new Date(timestamp).toLocaleString();
+}
+
+function restoreVersion() {
+  if (selectedVersion.value) {
+    emit('restore', selectedVersion.value.code);
+    props.onClose();
+  }
+}
+
+onMounted(() => {
+  if (props.open) {
+    loadVersions();
+  }
+});
+
+watch(() => props.open, (isOpen) => {
+  if (isOpen) {
+    loadVersions();
+  }
+});
+</script>
+
+<template>
+  <ModalDialog
+    :open="open"
+    :on-close="onClose"
+    extra-modal-class="w-[900px] h-[600px]"
+  >
+    <div class="flex flex-col h-full">
+      <h2 class="text-xl font-bold mb-4">Code Versions</h2>
+      
+      <div v-if="loading" class="flex-grow flex items-center justify-center">
+        <p>Loading versions...</p>
+      </div>
+      
+      <div v-else-if="versions.length === 0" class="flex-grow flex items-center justify-center">
+        <p>No previous versions found</p>
+      </div>
+      
+      <div v-else class="flex flex-row gap-4 h-[calc(100%-60px)]">
+        <!-- Left side: Code preview -->
+        <div class="w-3/5 h-full">
+          <MonacoEditor
+            v-model="selectedVersionCode"
+            lang="javascript"
+            class="h-full"
+            :options="{
+              readOnly: true,
+              scrollBeyondLastLine: false,
+              minimap: { enabled: false },
+              smoothScrolling: true,
+            }"
+          />
+        </div>
+        
+        <!-- Right side: Versions list -->
+        <div class="w-2/5 h-full flex flex-col">
+          <div class="overflow-y-auto flex-grow border border-gray-200">
+            <div
+              v-for="version in versions"
+              :key="version.versionId"
+              class="p-3 border-b cursor-pointer hover:bg-gray-100 transition"
+              :class="{ 'bg-gray-100': selectedVersion?.versionId === version.versionId }"
+              @click="selectVersion(version)"
+            >
+              <div class="font-medium">{{ formatDate(version.timestamp) }}</div>
+              <div class="text-sm text-gray-600">{{ version.versionId }}</div>
+            </div>
+          </div>
+          
+          <div class="mt-4 flex justify-end">
+            <button
+              class="h-10 px-6 font-semibold shadow bg-black text-white hover:bg-gray-800 transition"
+              @click="restoreVersion"
+              :disabled="!selectedVersion"
+            >
+              Restore This Version
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </ModalDialog>
+</template>

--- a/other/botCodeStore.ts
+++ b/other/botCodeStore.ts
@@ -1,5 +1,6 @@
 import EventEmitter from "node:events";
 import fs from "node:fs";
+import path from "node:path";
 
 const BOT_CODE_DIR = process.env.BOT_CODE_DIR || "./bot-code";
 
@@ -8,6 +9,11 @@ export interface BotCode {
   code: string;
   username: string;
   userId: number;
+}
+
+export interface BotCodeVersion extends BotCode {
+  timestamp: number;
+  versionId: string;
 }
 
 export type BotCodes = Record<string, BotCode>;
@@ -27,7 +33,11 @@ export function submitBotCode({ code, username, userId }: SubmitBotCodeArgs) {
   const id = Object.values(STORE).find(botCode => botCode.username === username)?.id || Math.random().toString(36).substring(5);
   const botCode = { id, code, username, userId };
   STORE[id] = botCode;
+  
+  // Save both the latest version and a timestamped version
   saveBot(botCode);
+  saveBotVersion(botCode);
+  
   botEventEmitter.emit("update", STORE);
 }
 
@@ -50,8 +60,14 @@ function loadBots() {
   }
 
   const files = fs.readdirSync(BOT_CODE_DIR);
+  
+  // Only load latest files (those without timestamp in the filename)
+  const latestFiles = files.filter(file => {
+    // Skip versioned files (those with timestamps)
+    return !file.includes('-v-');
+  });
 
-  for (const file of files) {
+  for (const file of latestFiles) {
     const code = fs.readFileSync(`${BOT_CODE_DIR}/${file}`, "utf8");
     const username = file.split("-")[0];
     const id = file.split("-")[1];
@@ -70,6 +86,60 @@ function saveBot({ id, code, username, userId }: BotCode) {
   const botCodeFile = `${BOT_CODE_DIR}/${username}-${id}-${userId}.js`;
 
   fs.writeFileSync(botCodeFile, code);
+}
+
+function saveBotVersion({ id, code, username, userId }: BotCode) {
+  if (!fs.existsSync(BOT_CODE_DIR)) {
+    fs.mkdirSync(BOT_CODE_DIR);
+  }
+  
+  const timestamp = Date.now();
+  const versionId = `v-${timestamp}`;
+  const botVersionFile = `${BOT_CODE_DIR}/${username}-${id}-${userId}-${versionId}.js`;
+
+  fs.writeFileSync(botVersionFile, code);
+}
+
+/**
+ * Gets all versions of code for a specific user
+ * @param userId The user ID to get versions for
+ * @returns Array of bot code versions sorted by timestamp (newest first)
+ */
+export function getUserCodeVersions(userId: number): BotCodeVersion[] {
+  if (!fs.existsSync(BOT_CODE_DIR)) {
+    return [];
+  }
+
+  const files = fs.readdirSync(BOT_CODE_DIR);
+  const userFiles = files.filter(file => {
+    const parts = file.split("-");
+    const fileUserId = parts[2]?.replace(".js", "");
+    return fileUserId === userId.toString() && parts.length >= 4 && parts[3]?.startsWith("v-");
+  });
+
+  const versions: BotCodeVersion[] = [];
+  
+  for (const file of userFiles) {
+    const code = fs.readFileSync(path.join(BOT_CODE_DIR, file), "utf8");
+    const parts = file.split("-");
+    const username = parts[0];
+    const id = parts[1];
+    const userId = parseInt(parts[2], 10);
+    const versionId = parts[3];
+    const timestamp = parseInt(versionId.replace("v-", ""), 10);
+    
+    versions.push({
+      id,
+      code,
+      username,
+      userId,
+      versionId,
+      timestamp
+    });
+  }
+  
+  // Sort by timestamp, newest first
+  return versions.sort((a, b) => b.timestamp - a.timestamp);
 }
 
 loadBots();

--- a/server/api/bot/versions.get.ts
+++ b/server/api/bot/versions.get.ts
@@ -1,0 +1,19 @@
+import { getUserCodeVersions } from "~/other/botCodeStore";
+
+export default defineEventHandler(async (event) => {
+  const userId = event.context.user.id;
+  
+  if (!userId) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: "Unauthorized"
+    });
+  }
+
+  // Get all code versions for the user
+  const versions = getUserCodeVersions(userId);
+  
+  return {
+    versions
+  };
+});


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->

## Description

This PR was created by `aider` ran in the [move-fast-and-break-things/swe-agents-comparison docker container](https://github.com/move-fast-and-break-things/swe-agents-comparison/tree/cdbd11475f55351b17e243ec8d60d3c6f51265c0) with:

```sh
aider --model anthropic/claude-3-7-sonnet-20250219 --yes-always --thinking-tokens 32k
```

Prompt:
> Please, solve the following issue. Title: feat: add code versions and an option to revert to a previous version. Description: **Goal:** let the user revert to the previous code version
> Proposed implementation:
> - every time the user submits code, store it separately, don't overwrite the previous code version
>     - we can use filenames with dates in them, for example: `<userid>-<timestamp>.js`
>     - use a special name, like `<userid>-latest.js` for the latest code version so we can quickly retrieve it by path
> - add a modal that will allow the user to view previous submissions in the UI and revert to them
>     - the button to open a modal should be above the code editor
>     - the modal left side should be occupied by the read-only code editor
>     - the modal on the right side should be occupied by the list of versions
>     - user can click any of the versions to preview them in the modal
>     - user can click the restore button to restore the version
>     - restoring the code doesn't create a new version until the user submits the code again
> Let me know if you want to work on this ticket and if you have any questions!

Cost: $0.12 USD.

## Notes

It never displays previous versions in the UI.

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/cc42fb76-ae90-480f-a95a-289620583058" />

## Checklist

- [ ] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
