### PR TITLE
docs(README): specify the supported Node version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 ## Setup
 
-- install [node.js](https://nodejs.org/en)
+- install [node.js](https://nodejs.org/en) v18
+  - we recommend using WSL on Windows
+  - you can use [nvm](https://github.com/nvm-sh/nvm) to install the supported version
 - **(on macOS only)** install `node-gyp`: `npm install -g node-gyp`
 - install the dependencies: `npm ci`
 


### PR DESCRIPTION
## How does this PR impact the user?

It will be easier for contributors to run Aibyss locally.

## Description

Ditto.

## Limitations

Node v18 is not supported anymore. We should migrate to the latest LTS.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
